### PR TITLE
fix: clamp max_tokens to fit OpenRouter provider context window

### DIFF
--- a/packages/provider/discover.go
+++ b/packages/provider/discover.go
@@ -286,6 +286,8 @@ func DiscoverOpenRouter(ctx context.Context, baseURL string) ([]Model, error) {
 		ctxWin := d.ContextLength
 		if ctxWin == 0 {
 			ctxWin = d.TopProvider.ContextLength
+		} else if d.TopProvider.ContextLength > 0 && d.TopProvider.ContextLength < ctxWin {
+			ctxWin = d.TopProvider.ContextLength
 		}
 		maxOut := 0
 		if d.TopProvider.MaxCompletionTokens != nil {

--- a/packages/provider/discover.go
+++ b/packages/provider/discover.go
@@ -284,9 +284,7 @@ func DiscoverOpenRouter(ctx context.Context, baseURL string) ([]Model, error) {
 			display = d.ID
 		}
 		ctxWin := d.ContextLength
-		if ctxWin == 0 {
-			ctxWin = d.TopProvider.ContextLength
-		} else if d.TopProvider.ContextLength > 0 && d.TopProvider.ContextLength < ctxWin {
+		if d.TopProvider.ContextLength > 0 && (ctxWin == 0 || d.TopProvider.ContextLength < ctxWin) {
 			ctxWin = d.TopProvider.ContextLength
 		}
 		maxOut := 0

--- a/packages/provider/openai.go
+++ b/packages/provider/openai.go
@@ -183,6 +183,31 @@ func (c *openaiClient) buildRequest(req Request) (*oaiRequest, error) {
 	if maxTok <= 0 {
 		maxTok = m.MaxOutput
 	}
+	// Clamp max_tokens so output + minimum input fits within the context
+	// window. Some providers (OpenRouter) enforce input + max_output <=
+	// context_length and reject requests where the total exceeds it.
+	// This reservation ensures basic user input (system prompt + first
+	// message + tool definitions) has room.
+	//
+	// Use the smaller of ContextWindow and MaxOutput as the cap because
+	// some providers (OpenRouter) report inflated model-level context
+	// windows (e.g. 1000000) while the serving provider enforces a much
+	// tighter limit (e.g. 262144). When both are wrong we still land on
+	// the output cap, which is the actual limit reported by the provider.
+	if m.ContextWindow > 0 && m.MaxOutput > 0 {
+		ctxCap := m.ContextWindow
+		if m.MaxOutput < ctxCap {
+			ctxCap = m.MaxOutput
+		}
+		const reserve = 4096
+		clamped := ctxCap - reserve
+		if clamped < 1024 {
+			clamped = 1024
+		}
+		if maxTok > clamped {
+			maxTok = clamped
+		}
+	}
 	if m.Reasoning {
 		if maxTok > 0 {
 			out.MaxCompletionTok = &maxTok


### PR DESCRIPTION
# Issue :
<img width="861" height="380" alt="image" src="https://github.com/user-attachments/assets/f26b156b-0eb6-424e-994c-6959ae98ec40" />

## Steps to reproduce: 
1. Use nemotron-3-super-120B or any model that have their context window equal to max output

<img width="1373" height="404" alt="image" src="https://github.com/user-attachments/assets/f28966a4-7d4f-4d9e-a1cb-733ef4626058" />

## Reason: 
1. OpenRouter inflated context_length: The API returns context_length: 1000000 (model's theoretical max), but the actual serving limit is top_provider.context_length: 262144. zot used the inflated value, making any ContextWindow-based checks useless.
3. Stale model cache: Previous discoveries cached ContextWindow=1000000 in models-cache.json. Even after fixing discovery, the stale cache was loaded first and the async refresh happened too late.
4. No max_tokens clamping: buildRequest set max_completion_tokens=MaxOutput=262144, which is the full context window. With even 1994 input tokens, total=264138 > 262144.

# Fixes:
## Three changes in two files:
1. openai.go : 
- Clamp max_tokens to min(ContextWindow, MaxOutput) - 4096. This is cache-proof, even if ContextWindow is stale/inflated (e.g., 1M), MaxOutput (262144) provides the real upper bound. Reserves 4096 tokens for input so max_output + input ≤ context_window.
- Changed condition from if m.ContextWindow > 0 && maxTok > m.ContextWindow-4096 to if m.ContextWindow > 0 && m.MaxOutput > 0 + using min(cap, MaxOutput), ensuring the clamp fires even when the cached ContextWindow is stale.

2. discover.go - Prefer top_provider.context_length over the model-level context_length when it's smaller, since the serving provider's limit is the one OpenRouter actually enforces.

<img width="841" height="547" alt="image" src="https://github.com/user-attachments/assets/28b08a01-629e-442e-a99d-76e8af18cfa8" />
