### PR TITLE
fix(provider): keep Z.AI /v4 base from getting a spurious /v1 chat path

### DIFF
--- a/packages/provider/openai.go
+++ b/packages/provider/openai.go
@@ -8,11 +8,31 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 )
 
 const openaiDefaultBaseURL = "https://api.openai.com"
+
+// versionSegmentSuffix matches a trailing API version segment such as
+// "/v1" or Z.AI's "/v4".
+var versionSegmentSuffix = regexp.MustCompile(`/v\d+$`)
+
+// chatCompletionsURL builds the chat-completions endpoint for an
+// OpenAI-compatible base URL. A base that already carries an API
+// version segment gets "/chat/completions" appended directly; a bare
+// host (e.g. api.openai.com) gets the conventional "/v1/chat/completions".
+//
+// Matching any "/vN" segment (not just "/v1") keeps Z.AI's coding-plan
+// base, which ends in "/paas/v4", from getting a spurious "/v1" that
+// yields ".../paas/v4/v1/chat/completions" and a 404.
+func chatCompletionsURL(baseURL string) string {
+	if versionSegmentSuffix.MatchString(baseURL) {
+		return baseURL + "/chat/completions"
+	}
+	return baseURL + "/v1/chat/completions"
+}
 
 type openaiClient struct {
 	apiKey  string
@@ -412,10 +432,7 @@ func buildOAIContentBlocks(blocks []Content, isError bool) []interface{} {
 // ---- streaming ----
 
 func (c *openaiClient) Stream(ctx context.Context, req Request) (<-chan Event, error) {
-	apiPath := "/v1/chat/completions"
-	if strings.HasSuffix(c.baseURL, "/v1") {
-		apiPath = "/chat/completions"
-	}
+	endpoint := chatCompletionsURL(c.baseURL)
 	wire, err := c.buildRequest(req)
 	if err != nil {
 		return nil, err
@@ -425,7 +442,7 @@ func (c *openaiClient) Stream(ctx context.Context, req Request) (<-chan Event, e
 		return nil, err
 	}
 	newReq := func() (*http.Request, error) {
-		httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+apiPath, bytes.NewReader(body))
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}

--- a/packages/provider/openai_url_test.go
+++ b/packages/provider/openai_url_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import "testing"
+
+// TestChatCompletionsURL pins the endpoint built for OpenAI-compatible
+// providers. The regression that motivated it: Z.AI's coding-plan base
+// carries a "/v4" version segment, so blindly appending
+// "/v1/chat/completions" produced ".../paas/v4/v1/chat/completions"
+// and a 404. Any base that already ends in a version segment must get
+// "/chat/completions" appended directly.
+func TestChatCompletionsURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "bare host gets conventional /v1 path",
+			baseURL: "https://api.openai.com",
+			want:    "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name:    "v1 base is not doubled",
+			baseURL: "https://api.moonshot.ai/v1",
+			want:    "https://api.moonshot.ai/v1/chat/completions",
+		},
+		{
+			name:    "zai coding plan v4 base is not given a spurious /v1",
+			baseURL: "https://api.z.ai/api/coding/paas/v4",
+			want:    "https://api.z.ai/api/coding/paas/v4/chat/completions",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chatCompletionsURL(tc.baseURL); got != tc.want {
+				t.Errorf("chatCompletionsURL(%q) = %q, want %q", tc.baseURL, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Selecting any Z.AI GLM model (e.g. `glm-4.7`) with a GLM Coding plan fails with a bare **404**.

`NewZAI` defaults to the coding-plan base `https://api.z.ai/api/coding/paas/v4` and routes through the generic OpenAI-compatible client. That client builds the request path like this:

```go
apiPath := "/v1/chat/completions"
if strings.HasSuffix(c.baseURL, "/v1") {
    apiPath = "/chat/completions"
}
```

It only recognises `/v1` as an already-present version segment. Z.AI's base ends in `/v4`, so the client appends `/v1/chat/completions` and sends the request to:

```
https://api.z.ai/api/coding/paas/v4/v1/chat/completions   ← spurious /v1 → 404
```

instead of the correct:

```
https://api.z.ai/api/coding/paas/v4/chat/completions
```

This affects every `zai` model, since they all share that base URL.

## Fix

Match any trailing `/vN` version segment, not just `/v1`, when deciding whether to append `/v1/chat/completions` or just `/chat/completions`. The path logic is extracted into a small pure helper, `chatCompletionsURL`, so it can be unit-tested directly.

This is **behaviour-identical for every existing provider** — all their versioned default bases end in `/v1` (`api.openai.com/v1`, `api.moonshot.ai/v1`, `api.cerebras.ai/v1`, …). The only base in the catalog ending in a non-`/v1` version segment is Z.AI's `/paas/v4`, which now resolves to the correct endpoint.

## Verification

- New table test `TestChatCompletionsURL` pins the bare-host, `/v1`, and `/v4` cases. It fails on the pre-fix logic (producing `.../paas/v4/v1/chat/completions`) and passes after.
- `go build ./...`, `go vet ./packages/provider/`, and `gofmt` are clean.
- Full `go test ./...` passes. (One agent env-discovery test, `TestResolveEnvOnlyBedrockDiscoveredWithoutConfig`, is unrelated and only fails when `ZAI_API_KEY` is present in the local environment; it passes with that unset and is unaffected by this change.)