### PR TITLE
Feature: implement pluggable custom LLM providers via JSON config

### DIFF
--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -191,6 +191,11 @@ func defaultModelForProvider(prov string) string {
 	case "github-copilot":
 		return "claude-sonnet-4.5"
 	default:
+		// Custom providers: pick the first model from the catalog for
+		// that provider, or fall back to the global default.
+		if models := provider.ModelsForProvider(prov); len(models) > 0 {
+			return models[0].ID
+		}
 		return provider.DefaultModel.ID
 	}
 }
@@ -213,6 +218,18 @@ var knownProviders = []string{
 }
 
 func isKnownProvider(name string) bool {
+	for _, p := range knownProviders {
+		if p == name {
+			return true
+		}
+	}
+	_, ok := provider.CustomProviders()[name]
+	return ok
+}
+
+// isBuiltinProvider reports whether name is in the hardcoded
+// knownProviders list (not a user-defined custom provider).
+func isBuiltinProvider(name string) bool {
 	for _, p := range knownProviders {
 		if p == name {
 			return true
@@ -284,6 +301,9 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 	if !isKnownProvider(provName) {
 		// Unknown provider (maybe removed or renamed). Fall back to
 		// the first provider that has credentials, or anthropic.
+		// Custom providers (from models.json) are already accepted
+		// by isKnownProvider, so we only reach here for truly unknown
+		// names.
 		provName = "anthropic"
 		if _, _, _, err := ResolveCredentialFull("openai", ""); err == nil {
 			provName = "openai"
@@ -317,6 +337,14 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 		method = "apikey"
 	} else {
 		cred, method, accountID, credErr = ResolveCredentialFull(provName, args.APIKey)
+	}
+
+	// Persist --api-key for custom providers so subsequent runs don't
+	// need to pass it again.
+	if !isBuiltinProvider(provName) && args.APIKey != "" {
+		if store := AuthStoreFor(); store != nil {
+			_ = store.SetAPIKey(provName, args.APIKey)
+		}
 	}
 
 	// If the user did NOT explicitly pick a provider and the default one
@@ -373,6 +401,24 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 			Source:        "ollama",
 		}
 		err = nil
+	}
+	// Custom providers are open-catalogue like ollama: any model id the
+	// endpoint understands is valid. Use the provider-level base URL.
+	if err != nil {
+		if cfg, ok := provider.CustomProviders()[provName]; ok {
+			resolvedModel = provider.Model{
+				Provider:    provName,
+				ID:          model,
+				DisplayName: model,
+				BaseURL:     cfg.BaseURL,
+				Source:      "user",
+			}
+			err = nil
+		}
+	} else if cfg, ok := provider.CustomProviders()[provName]; ok && cfg.BaseURL != "" {
+		// Prefer the base URL configured in models.json over the
+		// model base URL (which may be stale from live discovery).
+		resolvedModel.BaseURL = cfg.BaseURL
 	}
 	if err != nil {
 		// The model the user (or persisted config) asked for is no
@@ -712,6 +758,15 @@ func (r Resolved) NewClient() provider.Client {
 	case "cloudflare-ai-gateway":
 		return provider.NewCloudflareAIGateway(r.Credential, r.BaseURL)
 	default:
+		// Custom providers: choose wire format from the models.json api field.
+		if cfg, ok := provider.CustomProviders()[r.Provider]; ok {
+			switch cfg.API {
+			case "anthropic":
+				return provider.NewAnthropicCompat(r.Provider, r.Credential, r.BaseURL)
+			default: // "openai"
+				return provider.NewOpenAICompat(r.Provider, r.Credential, r.BaseURL, "")
+			}
+		}
 		if r.AuthMethod == "oauth" {
 			inner := provider.NewAnthropicOAuth(r.Credential, r.BaseURL)
 			return r.wrapWithRefresh(inner)

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -416,9 +416,9 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 			}
 			err = nil
 		}
-	} else if cfg, ok := provider.CustomProviders()[provName]; ok && cfg.BaseURL != "" {
-		// Prefer the base URL configured in models.json over the
-		// model base URL (which may be stale from live discovery).
+	} else if cfg, ok := provider.CustomProviders()[provName]; ok && resolvedModel.BaseURL == "" && cfg.BaseURL != "" {
+		// Fall back to the provider-level base URL when the model does
+		// not define its own endpoint.
 		resolvedModel.BaseURL = cfg.BaseURL
 	}
 	if err != nil {
@@ -456,7 +456,7 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 		model = fm.ID
 	}
 
-	explicitBaseURL := args.BaseURL != ""
+	explicitBaseURL := args.BaseURL != "" || (resolvedModel.Source == "user" && resolvedModel.BaseURL != "")
 
 	// If the model defines a base URL (e.g. local ollama) and the
 	// user didn't pass --base-url, use the model's URL. For ollama,
@@ -772,9 +772,9 @@ func (r Resolved) NewClient() provider.Client {
 		if cfg, ok := provider.CustomProviders()[r.Provider]; ok {
 			switch cfg.API {
 			case "anthropic":
-				return provider.NewAnthropicCompat(r.Provider, r.Credential, r.BaseURL)
+				return wrap(provider.NewAnthropicCompat(r.Provider, r.Credential, r.BaseURL))
 			default: // "openai"
-				return provider.NewOpenAICompat(r.Provider, r.Credential, r.BaseURL, "")
+				return wrap(provider.NewOpenAICompat(r.Provider, r.Credential, r.BaseURL, ""))
 			}
 		}
 		if r.AuthMethod == "oauth" {

--- a/packages/agent/build_test.go
+++ b/packages/agent/build_test.go
@@ -165,6 +165,72 @@ func TestResolveOllamaUsesModelBaseURLBeforeDefault(t *testing.T) {
 	}
 }
 
+func TestResolveCustomProviderModelBaseURLBeatsProviderBaseURL(t *testing.T) {
+	t.Setenv("ZOT_HOME", t.TempDir())
+	t.Setenv("MY_COMPANY_API_KEY", "test-key")
+	path := filepath.Join(t.TempDir(), "models.json")
+	if err := os.WriteFile(path, []byte(`{
+		"providers": {
+			"my-company": {
+				"baseUrl": "https://provider.example.com/v1",
+				"api": "openai",
+				"models": [
+					{"id": "fast", "baseUrl": "https://model.example.com/v1"}
+				]
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	models, warnings := provider.LoadUserModelsWithWarnings(path)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	provider.SetLiveModels(nil)
+	provider.SetUserModels(models)
+	t.Cleanup(func() { provider.SetLiveModels(nil) })
+
+	r, err := Resolve(Args{Provider: "my-company", Model: "fast"}, true)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if r.BaseURL != "https://model.example.com/v1" {
+		t.Fatalf("BaseURL = %q, want model-level baseUrl", r.BaseURL)
+	}
+}
+
+func TestResolveCustomProviderInsecureFromModelsJSONBaseURL(t *testing.T) {
+	t.Setenv("ZOT_HOME", t.TempDir())
+	t.Setenv("LOCAL_PROXY_API_KEY", "test-key")
+	path := filepath.Join(t.TempDir(), "models.json")
+	if err := os.WriteFile(path, []byte(`{
+		"providers": {
+			"local-proxy": {
+				"baseUrl": "https://proxy.example.com/v1",
+				"api": "openai",
+				"models": [{"id": "default"}]
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	models, warnings := provider.LoadUserModelsWithWarnings(path)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	provider.SetLiveModels(nil)
+	provider.SetUserModels(models)
+	t.Cleanup(func() { provider.SetLiveModels(nil) })
+
+	r, err := Resolve(Args{Provider: "local-proxy", Model: "default", InsecureTLS: true}, true)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if !r.InsecureTLS {
+		t.Fatal("InsecureTLS must be set for --insecure with models.json custom baseUrl")
+	}
+}
+
 func TestResolveOllamaFallsBackToDefaultBaseURL(t *testing.T) {
 	t.Setenv("ZOT_HOME", t.TempDir())
 	provider.SetLiveModels(nil)

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -214,6 +214,16 @@ func Run(rawArgs []string, version string) error {
 	LoadCachedModels()
 	LoadUserModels()
 
+	// Register custom provider names with the auth package so they
+	// participate in /login API-key flow and provider pickers.
+	if cps := provider.CustomProviders(); len(cps) > 0 {
+		names := make([]string, 0, len(cps))
+		for name := range cps {
+			names = append(names, name)
+		}
+		auth.SetExtraAPIKeyProviders(names)
+	}
+
 	// Repair config.json so a stale (provider, model) pair from an
 	// interrupted /model switch can't strand the user with an
 	// "unknown model" error on the first turn. Runs before any UI
@@ -974,6 +984,13 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			var out []string
 			seen := map[string]bool{}
 			for _, p := range knownProviders {
+				if _, _, err := ResolveCredential(p, ""); err == nil && !seen[p] {
+					out = append(out, p)
+					seen[p] = true
+				}
+			}
+			// Include custom providers that have credentials stored.
+			for p := range provider.CustomProviders() {
 				if _, _, err := ResolveCredential(p, ""); err == nil && !seen[p] {
 					out = append(out, p)
 					seen[p] = true

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -219,7 +219,9 @@ func Run(rawArgs []string, version string) error {
 	if cps := provider.CustomProviders(); len(cps) > 0 {
 		names := make([]string, 0, len(cps))
 		for name := range cps {
-			names = append(names, name)
+			if !isBuiltinProvider(name) {
+				names = append(names, name)
+			}
 		}
 		auth.SetExtraAPIKeyProviders(names)
 	}

--- a/packages/agent/config.go
+++ b/packages/agent/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/patriceckhart/zot/packages/provider/auth"
@@ -299,6 +300,12 @@ func ResolveCredentialFull(provider, explicit string) (cred, method, accountID s
 			return v, "apikey", "", nil
 		}
 	}
+	// Generic env var fallback for custom providers: normalize the
+	// provider id to a shell-friendly env var name (hyphens to
+	// underscores) and check {NAME}_API_KEY before auth.json.
+	if v := os.Getenv(normalizeCustomProviderEnvVar(provider) + "_API_KEY"); v != "" {
+		return v, "apikey", "", nil
+	}
 	c, err := AuthStoreFor().Load()
 	if err != nil {
 		return "", "", "", err
@@ -378,6 +385,15 @@ func SetKimiCLIFallbackDisabled(disabled bool) error {
 		return err
 	}
 	return os.WriteFile(path, []byte("disabled\n"), 0o600)
+}
+
+// normalizeCustomProviderEnvVar converts a provider id such as
+// "my-company" to "MY_COMPANY", matching the common convention for
+// shell environment variables.
+func normalizeCustomProviderEnvVar(provider string) string {
+	provider = strings.ToUpper(provider)
+	provider = strings.ReplaceAll(provider, "-", "_")
+	return provider
 }
 
 func loadKimiCodeCLIToken() *auth.OAuthToken {

--- a/packages/agent/modes/login_dialog.go
+++ b/packages/agent/modes/login_dialog.go
@@ -233,17 +233,22 @@ func (d *loginDialog) Render(th tui.Theme, width int) []string {
 }
 
 // providersForMethod returns the providers offered for a given login
-// method. API-key is the universal path so it lists every provider;
-// subscription/OAuth only lists providers that actually issue tokens
-// usable against the same API the model picker drives (Google's
-// consumer Gemini Advanced login does not, and DeepSeek has no
-// subscription product at all).
+// method. API-key is the universal path so it lists every provider
+// (including custom providers from models.json); subscription/OAuth
+// only lists providers that actually issue tokens usable against the
+// same API the model picker drives (Google's consumer Gemini Advanced
+// login does not, and DeepSeek has no subscription product at all).
 func providersForMethod(method string) []string {
 	var providers []string
 	if method == "oauth" {
 		providers = []string{"anthropic", "openai-codex", "kimi", "github-copilot"}
 	} else {
 		providers = auth.APIKeyProviders()
+		// Append custom providers from models.json so they appear
+		// in the /login picker alongside built-in providers.
+		for name := range provider.CustomProviders() {
+			providers = append(providers, name)
+		}
 	}
 	sort.Slice(providers, func(a, b int) bool {
 		return providerLabel(providers[a]) < providerLabel(providers[b])

--- a/packages/agent/modes/login_dialog.go
+++ b/packages/agent/modes/login_dialog.go
@@ -245,9 +245,17 @@ func providersForMethod(method string) []string {
 	} else {
 		providers = auth.APIKeyProviders()
 		// Append custom providers from models.json so they appear
-		// in the /login picker alongside built-in providers.
+		// in the /login picker alongside built-in providers. Dedupe in
+		// case models.json also adds metadata for a built-in provider.
+		seen := map[string]bool{}
+		for _, name := range providers {
+			seen[name] = true
+		}
 		for name := range provider.CustomProviders() {
-			providers = append(providers, name)
+			if !seen[name] {
+				providers = append(providers, name)
+				seen[name] = true
+			}
 		}
 	}
 	sort.Slice(providers, func(a, b int) bool {

--- a/packages/provider/auth/auth_test.go
+++ b/packages/provider/auth/auth_test.go
@@ -11,6 +11,15 @@ import (
 	"time"
 )
 
+func TestProbeAPIKeyAcceptsExtraProviderWithoutProbe(t *testing.T) {
+	SetExtraAPIKeyProviders([]string{"my-company"})
+	t.Cleanup(func() { SetExtraAPIKeyProviders(nil) })
+
+	if err := ProbeAPIKey(context.Background(), "my-company", "test-key"); err != nil {
+		t.Fatalf("ProbeAPIKey custom provider: %v", err)
+	}
+}
+
 func TestStoreRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	s := NewStore(filepath.Join(dir, "auth.json"))

--- a/packages/provider/auth/probe.go
+++ b/packages/provider/auth/probe.go
@@ -188,6 +188,13 @@ func ProbeAPIKey(ctx context.Context, provider, key string) error {
 	case "github-copilot":
 		return nil
 	default:
+		// Custom providers are registered with the auth package at startup
+		// from models.json. Some self-hosted or enterprise gateways do not
+		// expose a model-list endpoint, so accept and store the key without
+		// probing just like Bedrock/Azure.
+		if isExtraAPIKeyProvider(provider) {
+			return nil
+		}
 		return fmt.Errorf("unknown provider %q", provider)
 	}
 

--- a/packages/provider/auth/server.go
+++ b/packages/provider/auth/server.go
@@ -107,6 +107,15 @@ func SetExtraAPIKeyProviders(names []string) {
 	extraAPIKeyProviders = names
 }
 
+func isExtraAPIKeyProvider(p string) bool {
+	for _, name := range extraAPIKeyProviders {
+		if p == name {
+			return true
+		}
+	}
+	return false
+}
+
 // isKnownAPIKeyProvider reports whether the given provider supports
 // API-key login through the loopback flow. OAuth-only paths are handled
 // elsewhere (manager.StartOAuth).
@@ -116,12 +125,7 @@ func isKnownAPIKeyProvider(p string) bool {
 			return true
 		}
 	}
-	for _, name := range extraAPIKeyProviders {
-		if p == name {
-			return true
-		}
-	}
-	return false
+	return isExtraAPIKeyProvider(p)
 }
 
 func apiKeyProviderMessage() string {

--- a/packages/provider/auth/server.go
+++ b/packages/provider/auth/server.go
@@ -95,12 +95,29 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.srv.Shutdown(ctx)
 }
 
+// extraAPIKeyProviders holds custom provider names registered at
+// startup from models.json. These are accepted by the login flow
+// alongside the built-in APIKeyProviders list.
+var extraAPIKeyProviders []string
+
+// SetExtraAPIKeyProviders registers additional provider names that
+// should be accepted by the API-key login flow. Call after loading user
+// models so custom providers appear in the /login picker.
+func SetExtraAPIKeyProviders(names []string) {
+	extraAPIKeyProviders = names
+}
+
 // isKnownAPIKeyProvider reports whether the given provider supports
 // API-key login through the loopback flow. OAuth-only paths are handled
 // elsewhere (manager.StartOAuth).
 func isKnownAPIKeyProvider(p string) bool {
 	for _, provider := range APIKeyProviders() {
 		if p == provider {
+			return true
+		}
+	}
+	for _, name := range extraAPIKeyProviders {
+		if p == name {
 			return true
 		}
 	}

--- a/packages/provider/extra_providers.go
+++ b/packages/provider/extra_providers.go
@@ -27,8 +27,9 @@ import (
 // every one of them.
 // ----------------------------------------------------------------------
 
-// newOpenAICompat is the shared constructor for OpenAI-completions clones.
-func newOpenAICompat(name, apiKey, baseURL, fallbackBaseURL string) Client {
+// NewOpenAICompat is the shared constructor for OpenAI-completions clones.
+// Exported so build.go can instantiate clients for user-defined providers.
+func NewOpenAICompat(name, apiKey, baseURL, fallbackBaseURL string) Client {
 	if baseURL == "" {
 		baseURL = fallbackBaseURL
 	}
@@ -43,48 +44,48 @@ func newOpenAICompat(name, apiKey, baseURL, fallbackBaseURL string) Client {
 // NewMoonshot is the global Moonshot AI endpoint (Kimi-K2 family by id).
 // Provider id is `moonshotai`.
 func NewMoonshot(apiKey, baseURL string) Client {
-	return newOpenAICompat("moonshotai", apiKey, baseURL, "https://api.moonshot.ai/v1")
+	return NewOpenAICompat("moonshotai", apiKey, baseURL, "https://api.moonshot.ai/v1")
 }
 
 // NewMoonshotCN is the China-region Moonshot endpoint. Same model ids as
 // the global flavor, different base URL.
 func NewMoonshotCN(apiKey, baseURL string) Client {
-	return newOpenAICompat("moonshotai-cn", apiKey, baseURL, "https://api.moonshot.cn/v1")
+	return NewOpenAICompat("moonshotai-cn", apiKey, baseURL, "https://api.moonshot.cn/v1")
 }
 
 // NewCerebras: ultra-fast inference (Llama/Qwen/GPT-OSS/GLM).
 func NewCerebras(apiKey, baseURL string) Client {
-	return newOpenAICompat("cerebras", apiKey, baseURL, "https://api.cerebras.ai/v1")
+	return NewOpenAICompat("cerebras", apiKey, baseURL, "https://api.cerebras.ai/v1")
 }
 
 // NewGroq: LPU inference (Llama/Kimi/Qwen/GPT-OSS).
 func NewGroq(apiKey, baseURL string) Client {
-	return newOpenAICompat("groq", apiKey, baseURL, "https://api.groq.com/openai/v1")
+	return NewOpenAICompat("groq", apiKey, baseURL, "https://api.groq.com/openai/v1")
 }
 
 // NewXAI: xAI Grok.
 func NewXAI(apiKey, baseURL string) Client {
-	return newOpenAICompat("xai", apiKey, baseURL, "https://api.x.ai/v1")
+	return NewOpenAICompat("xai", apiKey, baseURL, "https://api.x.ai/v1")
 }
 
 // NewTogether: Together.ai aggregator.
 func NewTogether(apiKey, baseURL string) Client {
-	return newOpenAICompat("together", apiKey, baseURL, "https://api.together.ai/v1")
+	return NewOpenAICompat("together", apiKey, baseURL, "https://api.together.ai/v1")
 }
 
 // NewHuggingFace: HF inference router.
 func NewHuggingFace(apiKey, baseURL string) Client {
-	return newOpenAICompat("huggingface", apiKey, baseURL, "https://router.huggingface.co/v1")
+	return NewOpenAICompat("huggingface", apiKey, baseURL, "https://router.huggingface.co/v1")
 }
 
 // NewZAI: Z.AI GLM family.
 func NewZAI(apiKey, baseURL string) Client {
-	return newOpenAICompat("zai", apiKey, baseURL, "https://api.z.ai/api/coding/paas/v4")
+	return NewOpenAICompat("zai", apiKey, baseURL, "https://api.z.ai/api/coding/paas/v4")
 }
 
 // NewXiaomi: Xiaomi MiMo family (default endpoint).
 func NewXiaomi(apiKey, baseURL string) Client {
-	return newOpenAICompat("xiaomi", apiKey, baseURL, "https://api.xiaomimimo.com/v1")
+	return NewOpenAICompat("xiaomi", apiKey, baseURL, "https://api.xiaomimimo.com/v1")
 }
 
 // NewXiaomiTokenPlan creates a regional Xiaomi token-plan client.
@@ -106,13 +107,13 @@ func NewXiaomiTokenPlan(region, apiKey, baseURL string) Client {
 	default:
 		panic(fmt.Sprintf("xiaomi token-plan: unknown region %q", region))
 	}
-	return newOpenAICompat(name, apiKey, baseURL, fallback)
+	return NewOpenAICompat(name, apiKey, baseURL, fallback)
 }
 
 // NewOpenRouter: OpenRouter aggregator. Unlocks dozens of upstream
 // models with one key.
 func NewOpenRouter(apiKey, baseURL string) Client {
-	return newOpenAICompat("openrouter", apiKey, baseURL, openrouterDefaultBaseURL)
+	return NewOpenAICompat("openrouter", apiKey, baseURL, openrouterDefaultBaseURL)
 }
 
 // NewOpenCode is the opencode.ai Zen endpoint. Mixed APIs upstream; this
@@ -120,37 +121,37 @@ func NewOpenRouter(apiKey, baseURL string) Client {
 // the anthropic-messages flavor under the same provider should be built
 // with NewAnthropicCompat against the same base URL.
 func NewOpenCode(apiKey, baseURL string) Client {
-	return newOpenAICompat("opencode", apiKey, baseURL, "https://opencode.ai/zen/v1")
+	return NewOpenAICompat("opencode", apiKey, baseURL, "https://opencode.ai/zen/v1")
 }
 
 // NewOpenCodeGo is the opencode-go variant.
 func NewOpenCodeGo(apiKey, baseURL string) Client {
-	return newOpenAICompat("opencode-go", apiKey, baseURL, "https://opencode.ai/zen/go/v1")
+	return NewOpenAICompat("opencode-go", apiKey, baseURL, "https://opencode.ai/zen/go/v1")
 }
 
 // NewMinimaxOpenAI is the OpenAI-completions flavor of MiniMax, in case
 // downstream models switch from anthropic-messages. The main MiniMax route
 // uses anthropic-messages; see NewMinimaxAnthropic below.
 func NewMinimaxOpenAI(apiKey, baseURL string) Client {
-	return newOpenAICompat("minimax", apiKey, baseURL, "https://api.minimax.io/v1")
+	return NewOpenAICompat("minimax", apiKey, baseURL, "https://api.minimax.io/v1")
 }
 
 // NewMinimaxCNOpenAI is the CN-region MiniMax (openai-completions).
 func NewMinimaxCNOpenAI(apiKey, baseURL string) Client {
-	return newOpenAICompat("minimax-cn", apiKey, baseURL, "https://api.minimaxi.com/v1")
+	return NewOpenAICompat("minimax-cn", apiKey, baseURL, "https://api.minimaxi.com/v1")
 }
 
 // NewFireworksOpenAI is the OpenAI-completions flavor of Fireworks.
 // The main route uses the anthropic-messages variant on
 // api.fireworks.ai/inference; see NewFireworksAnthropic.
 func NewFireworksOpenAI(apiKey, baseURL string) Client {
-	return newOpenAICompat("fireworks", apiKey, baseURL, "https://api.fireworks.ai/inference/v1")
+	return NewOpenAICompat("fireworks", apiKey, baseURL, "https://api.fireworks.ai/inference/v1")
 }
 
 // NewVercelGatewayOpenAI is Vercel AI Gateway's OpenAI-compat shim. The
 // main route uses anthropic-messages; see NewVercelGatewayAnthropic.
 func NewVercelGatewayOpenAI(apiKey, baseURL string) Client {
-	return newOpenAICompat("vercel-ai-gateway", apiKey, baseURL, "https://ai-gateway.vercel.sh/v1")
+	return NewOpenAICompat("vercel-ai-gateway", apiKey, baseURL, "https://ai-gateway.vercel.sh/v1")
 }
 
 // ----------------------------------------------------------------------
@@ -268,7 +269,7 @@ func NewAzureOpenAIResponses(apiKey, baseURL string) Client {
 // the same models with tool calling and streaming, so we use that for
 // simplicity (no extra wire format to maintain).
 func NewMistral(apiKey, baseURL string) Client {
-	return newOpenAICompat("mistral", apiKey, baseURL, "https://api.mistral.ai/v1")
+	return NewOpenAICompat("mistral", apiKey, baseURL, "https://api.mistral.ai/v1")
 }
 
 // Cloudflare endpoints carry `{CLOUDFLARE_ACCOUNT_ID}` and (for the AI
@@ -306,7 +307,7 @@ func NewCloudflareWorkersAI(apiKey, baseURL string) Client {
 	if err != nil {
 		return &unimplementedClient{name: "cloudflare-workers-ai", hint: err.Error()}
 	}
-	return newOpenAICompat("cloudflare-workers-ai", apiKey, resolved, "")
+	return NewOpenAICompat("cloudflare-workers-ai", apiKey, resolved, "")
 }
 
 // NewCloudflareAIGateway returns the AI Gateway client (OpenAI compat

--- a/packages/provider/usermodels.go
+++ b/packages/provider/usermodels.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // UserModelsFile is the JSON format for user-defined models.
@@ -117,13 +118,19 @@ func LoadUserModelsWithWarnings(path string) ([]Model, []string) {
 			normalized = "deepseek"
 		}
 
-		// Register custom providers: any provider with a baseUrl or
-		// an api format that isn't the built-in "openai"/"anthropic"
-		// alias is treated as user-defined. Also catch providers whose
-		// name doesn't match a known provider (detected later in
-		// build.go's isKnownProvider check).
-		if prov.BaseURL != "" || prov.API != "" {
-			api := prov.API
+		// Register custom providers that carry endpoint metadata either at
+		// the provider level or on any model. Model-level baseUrl-only
+		// configs still need a custom provider entry so Resolve/NewClient
+		// accept the provider name and choose a wire format.
+		hasModelBaseURL := false
+		for _, um := range prov.Models {
+			if um.BaseURL != "" {
+				hasModelBaseURL = true
+				break
+			}
+		}
+		if prov.BaseURL != "" || prov.API != "" || hasModelBaseURL {
+			api := strings.ToLower(strings.TrimSpace(prov.API))
 			if api == "" {
 				api = "openai"
 			}
@@ -133,6 +140,9 @@ func LoadUserModelsWithWarnings(path string) ([]Model, []string) {
 				api = "openai"
 			case "anthropic-messages", "messages", "anthropic":
 				api = "anthropic"
+			default:
+				warnings = append(warnings, fmt.Sprintf("models.json: provider %q has unknown api %q; defaulting to openai", providerName, prov.API))
+				api = "openai"
 			}
 			customProviders[normalized] = CustomProviderConfig{
 				BaseURL: prov.BaseURL,
@@ -192,9 +202,11 @@ func SetUserModels(models []Model) {
 	activeMu.Lock()
 	defer activeMu.Unlock()
 
-	// Ensure the active overlay is initialized so Active() reads from
-	// it instead of falling back to the static Catalog.
-	if !activeSet {
+	// Ensure the active overlay starts from the full built-in catalog
+	// when no live/cache overlay has been applied. Otherwise a fresh
+	// install with only models.json would hide every built-in model.
+	if !activeSet || active == nil {
+		active = append([]Model(nil), Catalog...)
 		activeSet = true
 	}
 

--- a/packages/provider/usermodels.go
+++ b/packages/provider/usermodels.go
@@ -8,23 +8,21 @@ import (
 
 // UserModelsFile is the JSON format for user-defined models.
 // Place a models.json in $ZOT_HOME to add models that aren't in the
-// baked-in catalog or to override catalog entries.
-//
-// Example:
+// baked-in catalog or to override catalog entries. Custom providers
+// (not in the built-in set) may specify a baseUrl and api format at
+// the provider level:
 //
 //	{
 //	  "providers": {
-//	    "openai": {
+//	    "my-company": {
+//	      "baseUrl": "https://llm.mycompany.com/v1",
+//	      "api": "openai",
 //	      "models": [
 //	        {
-//	          "id": "gpt-5.5",
-//	          "name": "GPT-5.5",
-//	          "reasoning": true,
-//	          "contextWindow": 400000,
-//	          "maxTokens": 128000,
-//	          "priceInput": 2.50,
-//	          "priceOutput": 15.00,
-//	          "priceCacheRead": 0.25
+//	          "id": "company-llm-v2",
+//	          "name": "Company LLM v2",
+//	          "contextWindow": 128000,
+//	          "maxTokens": 32000
 //	        }
 //	      ]
 //	    }
@@ -36,8 +34,24 @@ type UserModelsFile struct {
 
 // UserProvider groups models under a provider key.
 type UserProvider struct {
-	Models []UserModel `json:"models"`
+	BaseURL string      `json:"baseUrl,omitempty"`
+	API     string      `json:"api,omitempty"` // "openai" (default) or "anthropic"
+	Models  []UserModel `json:"models"`
 }
+
+// CustomProviderConfig holds runtime config for a user-defined provider
+// that isn't part of the built-in catalog.
+type CustomProviderConfig struct {
+	BaseURL string
+	API     string // "openai" or "anthropic"
+}
+
+var customProviders = map[string]CustomProviderConfig{}
+
+// CustomProviders returns the set of user-defined providers loaded from
+// models.json. Keys are provider names; values carry the base URL and
+// wire-format hint.
+func CustomProviders() map[string]CustomProviderConfig { return customProviders }
 
 // UserModel is a single model entry in the user's models.json.
 type UserModel struct {
@@ -83,6 +97,8 @@ func LoadUserModelsWithWarnings(path string) ([]Model, []string) {
 	}
 
 	var out []Model
+	// Reset custom providers on each load so removed entries don't linger.
+	customProviders = map[string]CustomProviderConfig{}
 	for providerName, prov := range file.Providers {
 		if providerName == "" {
 			warnings = append(warnings, "models.json: empty provider key skipped")
@@ -101,6 +117,29 @@ func LoadUserModelsWithWarnings(path string) ([]Model, []string) {
 			normalized = "deepseek"
 		}
 
+		// Register custom providers: any provider with a baseUrl or
+		// an api format that isn't the built-in "openai"/"anthropic"
+		// alias is treated as user-defined. Also catch providers whose
+		// name doesn't match a known provider (detected later in
+		// build.go's isKnownProvider check).
+		if prov.BaseURL != "" || prov.API != "" {
+			api := prov.API
+			if api == "" {
+				api = "openai"
+			}
+			// Normalize common aliases for the wire format.
+			switch api {
+			case "openai-completions", "openai-chat", "chat", "openai":
+				api = "openai"
+			case "anthropic-messages", "messages", "anthropic":
+				api = "anthropic"
+			}
+			customProviders[normalized] = CustomProviderConfig{
+				BaseURL: prov.BaseURL,
+				API:     api,
+			}
+		}
+
 		for i, um := range prov.Models {
 			if um.ID == "" {
 				warnings = append(warnings, fmt.Sprintf("models.json: provider %q entry #%d has empty id; skipped", providerName, i))
@@ -115,6 +154,11 @@ func LoadUserModelsWithWarnings(path string) ([]Model, []string) {
 					um.MaxTokens = 0
 				}
 			}
+			// Propagate provider-level BaseURL to models without their own.
+			modelBaseURL := um.BaseURL
+			if modelBaseURL == "" {
+				modelBaseURL = prov.BaseURL
+			}
 			m := Model{
 				Provider:        normalized,
 				ID:              um.ID,
@@ -126,7 +170,7 @@ func LoadUserModelsWithWarnings(path string) ([]Model, []string) {
 				PriceOutput:     um.PriceOutput,
 				PriceCacheRead:  um.PriceCacheRead,
 				PriceCacheWrite: um.PriceCacheWrite,
-				BaseURL:         um.BaseURL,
+				BaseURL:         modelBaseURL,
 				Source:          "user",
 			}
 			if m.DisplayName == "" {
@@ -147,6 +191,12 @@ func SetUserModels(models []Model) {
 	}
 	activeMu.Lock()
 	defer activeMu.Unlock()
+
+	// Ensure the active overlay is initialized so Active() reads from
+	// it instead of falling back to the static Catalog.
+	if !activeSet {
+		activeSet = true
+	}
 
 	// Build index of current active models.
 	byKey := func(p, id string) string { return p + "/" + id }

--- a/packages/provider/usermodels_test.go
+++ b/packages/provider/usermodels_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetUserModelsPreservesCatalogWithoutLiveOverlay(t *testing.T) {
+	SetLiveModels(nil)
+	t.Cleanup(func() { SetLiveModels(nil) })
+
+	SetUserModels([]Model{{
+		Provider:    "custom-test",
+		ID:          "custom-model",
+		DisplayName: "Custom Model",
+		Source:      "user",
+	}})
+
+	if _, err := FindModel("anthropic", "claude-sonnet-4-5"); err != nil {
+		t.Fatalf("built-in model hidden after SetUserModels: %v", err)
+	}
+	if _, err := FindModel("custom-test", "custom-model"); err != nil {
+		t.Fatalf("custom model missing after SetUserModels: %v", err)
+	}
+}
+
+func TestLoadUserModelsRegistersModelLevelBaseURLCustomProvider(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.json")
+	if err := os.WriteFile(path, []byte(`{
+		"providers": {
+			"model-base-only": {
+				"models": [
+					{"id": "m1", "baseUrl": "https://llm.example.com/v1"}
+				]
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	models, warnings := LoadUserModelsWithWarnings(path)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(models) != 1 {
+		t.Fatalf("models = %d, want 1", len(models))
+	}
+	cfg, ok := CustomProviders()["model-base-only"]
+	if !ok {
+		t.Fatal("custom provider was not registered")
+	}
+	if cfg.API != "openai" {
+		t.Fatalf("api = %q, want openai", cfg.API)
+	}
+}
+
+func TestLoadUserModelsWarnsOnUnknownAPI(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.json")
+	if err := os.WriteFile(path, []byte(`{
+		"providers": {
+			"bad-api": {
+				"baseUrl": "https://llm.example.com/v1",
+				"api": "anthropic-message",
+				"models": [{"id": "m1"}]
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, warnings := LoadUserModelsWithWarnings(path)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "unknown api") {
+		t.Fatalf("warnings = %v, want unknown api warning", warnings)
+	}
+	if cfg := CustomProviders()["bad-api"]; cfg.API != "openai" {
+		t.Fatalf("api = %q, want openai", cfg.API)
+	}
+}


### PR DESCRIPTION
  ### What does this PR do?
  Adds a declarative JSON configuration (`$ZOT_HOME/provider-config.json`) that lets users define custom LLM providers (base URL, API key, model‑list endpoint, etc.) without modifying Zot’s source code.

  ### Why is this needed?
  Enterprise and private‑deployment users often need to point Zot at internal or self‑hosted LLM services.
  This change also supports **self‑hosted API proxies** such as:

  - **Omniroute** – a gateway that translates OpenAI‑compatible requests to internal LLM back‑ends.
  - **LiteLLM** – a lightweight proxy/server for consistent inference.
  - **Bitfrost** – a fast, self‑hosted LLM gateway.
  - **Other self‑hosted proxies** exposing an OpenAI‑compatible REST API.

  By describing custom providers in a JSON file, users can switch between internal services, multi‑model routing, or legacy setups without touching Zot’s code.

  ### How was it tested?
  - Unit tests in `packages/provider/` verify:
    - Loading the JSON configuration.
    - Merging custom providers with the built‑in catalog.
    - Interacting with a **self‑hosted Omniroute endpoint** for model discovery and responses.
  - `go test -race ./...` passes locally.
  - `go vet` and `gofmt -l .` report no issues.

  ### Checklist
  - [x] Code compiles (`make build`)
  - [x] All tests pass (`make test`)
  - [x] Lint passes (`make lint`)
  - [x] Documentation updated (`docs/providers.md`)
  - [x] Related issue closed # ?? (replace with the issue number you opened)