### PR TITLE
fix(swarm): ignore tool-loop turn_end for completion

### DIFF
--- a/packages/agent/modes/interactive.go
+++ b/packages/agent/modes/interactive.go
@@ -5103,12 +5103,13 @@ func (i *Interactive) TrackSwarmAgent(a *swarm.Agent, task string) {
 }
 
 // trackSwarmAgent records a freshly-spawned auto-swarm agent and
-// subscribes to its turn_end events. Sub-agents are long-lived
-// daemons that keep running on the inbox after the initial task,
-// so we can't wait on agent.Wait() — it never returns until the
-// whole daemon dies. Instead we mark each entry done on its first
-// turn_end (the initial task finishing), and when every tracked
-// entry has reported in, flush a single summary into the main chat.
+// subscribes to its prompt-level task completion events. Sub-agents
+// are long-lived daemons that keep running on the inbox after the
+// initial task, so we can't wait on agent.Wait() — it never returns
+// until the whole daemon dies. Instead we mark each entry done when
+// the swarm daemon reports the initial prompt has finished, and when
+// every tracked entry has reported in, flush a single summary into
+// the main chat.
 //
 // Wired in from cli.go via SwarmSpawnTool.OnSpawned only when auto-
 // swarm is enabled, so this is a no-op when the feature is off.

--- a/packages/agent/swarm/agent.go
+++ b/packages/agent/swarm/agent.go
@@ -71,12 +71,15 @@ type Agent struct {
 	finished   time.Time
 	lastErr    error
 
-	// OnTurnEnd, if set, fires once per turn_end event the runner
-	// observes from the child daemon. Used by auto-swarm watchers
-	// to detect that a sub-agent's first (or n-th) task has
-	// finished without waiting for the long-lived daemon itself to
-	// exit — sub-agents keep running on the inbox even after the
-	// initial task completes, so Wait() never unblocks for them.
+	// OnTurnEnd, if set, fires once per prompt-level turn_end event
+	// emitted by the swarm daemon wrapper. Provider/tool-loop
+	// turn_end events (for example stop=tool_use) are ignored by the
+	// runner because they do not mean the sub-agent task finished.
+	// Used by auto-swarm watchers to detect that a sub-agent's first
+	// (or n-th) task has finished without waiting for the long-lived
+	// daemon itself to exit — sub-agents keep running on the inbox
+	// even after the initial task completes, so Wait() never unblocks
+	// for them.
 	OnTurnEnd func(step int, errMsg string)
 
 	ctx    context.Context
@@ -128,10 +131,10 @@ func (a *Agent) Err() error {
 // and by /swarm wait <id>.
 func (a *Agent) Wait() { <-a.done }
 
-// SetOnTurnEnd installs (or clears, with nil) the per-turn callback
-// fired from the runner when the child daemon emits a turn_end
-// event. Safe to call from any goroutine: the runner reads the
-// callback under the same mutex.
+// SetOnTurnEnd installs (or clears, with nil) the callback fired
+// from the runner when the child daemon emits a prompt-level
+// turn_end event with a step field. Safe to call from any goroutine:
+// the runner reads the callback under the same mutex.
 func (a *Agent) SetOnTurnEnd(fn func(step int, errMsg string)) {
 	a.mu.Lock()
 	a.OnTurnEnd = fn

--- a/packages/agent/swarm/runner.go
+++ b/packages/agent/swarm/runner.go
@@ -209,21 +209,13 @@ func (r *execRunner) Run(ctx context.Context, sink Sink) error {
 				if ev, ok := parseEventLine(trimmed); ok {
 					_ = log.Append(ev)
 					applyEventToSink(ev, sink)
-					// Fan turn_end up to any subscriber on the
-					// supervised Agent. Daemons stay alive across
-					// many turns, so Wait()-style hooks would
-					// never fire; per-turn callbacks let auto-
-					// swarm summarise as each task completes.
-					if ev.Type == "turn_end" && r.agent != nil {
-						r.agent.mu.Lock()
-						fn := r.agent.OnTurnEnd
-						r.agent.mu.Unlock()
-						if fn != nil {
-							step, _ := ev.Data["step"].(float64)
-							errMsg, _ := ev.Data["error"].(string)
-							go fn(int(step), errMsg)
-						}
-					}
+					// Fan prompt-level task completions up to any
+					// subscriber on the supervised Agent. The child
+					// also forwards provider/tool-loop turn_end
+					// events (for example stop=tool_use); those do
+					// not contain step and must not be treated as
+					// swarm task completion.
+					notifyPromptTurnEnd(r.agent, ev)
 				} else {
 					// Non-JSON output. Keep it as transcript so an
 					// accidental fmt.Println in the child still
@@ -299,6 +291,28 @@ func parseEventLine(line string) (Event, bool) {
 		ev.Time = time.Now()
 	}
 	return ev, true
+}
+
+// notifyPromptTurnEnd calls Agent.OnTurnEnd only for the swarm
+// daemon's prompt-level completion event. Provider/tool-loop
+// turn_end events (such as stop=tool_use) do not include step and
+// are not terminal for the delegated task.
+func notifyPromptTurnEnd(a *Agent, ev Event) {
+	if a == nil || ev.Type != "turn_end" {
+		return
+	}
+	step, ok := ev.Data["step"].(float64)
+	if !ok {
+		return
+	}
+
+	a.mu.Lock()
+	fn := a.OnTurnEnd
+	a.mu.Unlock()
+	if fn != nil {
+		errMsg, _ := ev.Data["error"].(string)
+		go fn(int(step), errMsg)
+	}
 }
 
 // applyEventToSink translates an Event into Sink updates. Only a

--- a/packages/agent/swarm/runner_test.go
+++ b/packages/agent/swarm/runner_test.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestSwarmAgentArgs locks in the exact flag set the subprocess
@@ -120,6 +121,45 @@ func TestDefaultChildArgsResumeOmitsTask(t *testing.T) {
 	}
 	if strings.HasPrefix(args[len(args)-1], "--") {
 		t.Fatalf("resume argv ends on a bare flag (no value): %v", args)
+	}
+}
+
+func TestNotifyPromptTurnEndIgnoresProviderToolLoopTurnEnd(t *testing.T) {
+	called := make(chan struct{}, 1)
+	a := &Agent{}
+	a.SetOnTurnEnd(func(step int, errMsg string) {
+		called <- struct{}{}
+	})
+
+	notifyPromptTurnEnd(a, NewEvent("turn_end", map[string]any{"stop": "tool_use"}))
+
+	select {
+	case <-called:
+		t.Fatal("OnTurnEnd fired for provider/tool-loop turn_end without step")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestNotifyPromptTurnEndFiresForDaemonPromptCompletion(t *testing.T) {
+	type got struct {
+		step int
+		err  string
+	}
+	called := make(chan got, 1)
+	a := &Agent{}
+	a.SetOnTurnEnd(func(step int, errMsg string) {
+		called <- got{step: step, err: errMsg}
+	})
+
+	notifyPromptTurnEnd(a, NewEvent("turn_end", map[string]any{"step": float64(2), "error": "boom"}))
+
+	select {
+	case g := <-called:
+		if g.step != 2 || g.err != "boom" {
+			t.Fatalf("callback = (%d, %q); want (2, boom)", g.step, g.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("OnTurnEnd did not fire for prompt-level turn_end with step")
 	}
 }
 


### PR DESCRIPTION
## Summary
- only fire swarm OnTurnEnd for prompt-level turn_end events that include a step
- ignore provider/tool-loop turn_end events such as stop=tool_use so auto-swarm summaries do not flush early
- clarify comments around prompt-level completion tracking

## Test
- go test ./packages/agent/swarm