### PR TITLE
fix: run MCP servers from project directory

### DIFF
--- a/examples/extensions/mcp-bridge/bridge.go
+++ b/examples/extensions/mcp-bridge/bridge.go
@@ -33,6 +33,7 @@ type toolMapping struct {
 // bridge connects MCP servers to zot's extension protocol.
 type bridge struct {
 	e *ext.Extension
+	cwd string
 	// servers is written once in loadServers before any goroutine
 	// starts, and read-only afterwards — that invariant is what makes
 	// the lock-free reads in handleToolCall and the idle reaper safe.
@@ -45,9 +46,10 @@ type bridge struct {
 }
 
 // newBridge creates a new MCP→zot bridge.
-func newBridge(e *ext.Extension, logger *log.Logger) *bridge {
+func newBridge(e *ext.Extension, cwd string, logger *log.Logger) *bridge {
 	return &bridge{
 		e:       e,
+		cwd:     cwd,
 		servers: make(map[string]*managedServer),
 		mapping: make(map[string]toolMapping),
 		logger:  logger,
@@ -78,7 +80,7 @@ func toolName(serverName, mcpToolName string) string {
 // loadServers reads the config and creates managed servers.
 func (b *bridge) loadServers(cfg Config) {
 	for name, srvCfg := range cfg.MCPServers {
-		srv := newManagedServer(name, srvCfg, b.logger)
+		srv := newManagedServer(name, srvCfg, b.cwd, b.logger)
 		b.servers[name] = srv
 	}
 }

--- a/examples/extensions/mcp-bridge/bridge.go
+++ b/examples/extensions/mcp-bridge/bridge.go
@@ -32,7 +32,7 @@ type toolMapping struct {
 
 // bridge connects MCP servers to zot's extension protocol.
 type bridge struct {
-	e *ext.Extension
+	e   *ext.Extension
 	cwd string
 	// servers is written once in loadServers before any goroutine
 	// starts, and read-only afterwards — that invariant is what makes

--- a/examples/extensions/mcp-bridge/bridge_test.go
+++ b/examples/extensions/mcp-bridge/bridge_test.go
@@ -12,6 +12,7 @@ import (
 
 func testBridge() *bridge {
 	return &bridge{
+		cwd:     "/project",
 		servers: map[string]*managedServer{},
 		mapping: map[string]toolMapping{},
 		logger:  log.New(io.Discard, "", 0),
@@ -30,12 +31,23 @@ func TestHandleToolCallStartFailureIsFriendlyError(t *testing.T) {
 	b := testBridge()
 	b.servers["bogus"] = newManagedServer("bogus",
 		ServerConfig{Transport: "no-such-transport", ConnectTimeout: 1, RequestTimeout: 1},
+		"/project",
 		log.New(io.Discard, "", 0))
 	b.mapping["mcp__bogus__t"] = toolMapping{serverName: "bogus", mcpTool: "t"}
 
 	res := b.handleToolCall("mcp__bogus__t", nil)
 	if !res.IsError {
 		t.Fatal("expected error result for failed server start")
+	}
+}
+
+func TestLoadServersPassesProjectCWD(t *testing.T) {
+	b := testBridge()
+	b.loadServers(Config{MCPServers: map[string]ServerConfig{
+		"fs": {Transport: "stdio", Command: "dummy"},
+	}})
+	if got := b.servers["fs"].cwd; got != "/project" {
+		t.Fatalf("managed server cwd = %q, want /project", got)
 	}
 }
 

--- a/examples/extensions/mcp-bridge/main.go
+++ b/examples/extensions/mcp-bridge/main.go
@@ -76,7 +76,7 @@ func main() {
 
 		logger.Printf("found %d MCP server(s)", len(cfg.MCPServers))
 
-		b = newBridge(e, logger)
+		b = newBridge(e, cwd, logger)
 		b.loadServers(cfg)
 
 		cachePath := toolCachePath()

--- a/examples/extensions/mcp-bridge/server.go
+++ b/examples/extensions/mcp-bridge/server.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +56,7 @@ func (s serverState) String() string {
 type managedServer struct {
 	name   string
 	config ServerConfig
+	cwd    string
 	logger *log.Logger
 
 	mu       sync.Mutex
@@ -66,10 +69,11 @@ type managedServer struct {
 }
 
 // newManagedServer creates a new server wrapper.
-func newManagedServer(name string, cfg ServerConfig, logger *log.Logger) *managedServer {
+func newManagedServer(name string, cfg ServerConfig, cwd string, logger *log.Logger) *managedServer {
 	return &managedServer{
 		name:     name,
 		config:   cfg,
+		cwd:      cwd,
 		logger:   logger,
 		state:    stateStopped,
 		lastUsed: time.Now(),
@@ -186,8 +190,25 @@ func (s *managedServer) startStdio() (*client.Client, error) {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// Create stdio client (this spawns the subprocess)
-	c, err := client.NewStdioMCPClient(s.config.Command, env, s.config.Args...)
+	// Create stdio client (this spawns the subprocess). Run stdio MCP
+	// servers from the zot session's project directory, not the installed
+	// extension directory. Many MCP servers use their process cwd as their
+	// project root when answering relative-path or directory-listing
+	// requests, so inheriting mcp-bridge's cwd makes them operate on the
+	// extension install instead of the user's project.
+	c, err := client.NewStdioMCPClientWithOptions(
+		s.config.Command,
+		env,
+		s.config.Args,
+		transport.WithCommandFunc(func(ctx context.Context, command string, env []string, args []string) (*exec.Cmd, error) {
+			cmd := exec.CommandContext(ctx, command, args...)
+			cmd.Env = append(os.Environ(), env...)
+			if s.cwd != "" {
+				cmd.Dir = s.cwd
+			}
+			return cmd, nil
+		}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("spawn %s: %w", s.config.Command, err)
 	}

--- a/examples/extensions/mcp-bridge/status_test.go
+++ b/examples/extensions/mcp-bridge/status_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestManagedServerStatusCompact(t *testing.T) {
-	s := newManagedServer("grep", ServerConfig{}, log.New(io.Discard, "", 0))
+	s := newManagedServer("grep", ServerConfig{}, "", log.New(io.Discard, "", 0))
 
 	s.state = stateReady
 	s.tools = []mcp.Tool{{Name: "searchGitHub"}}
@@ -38,10 +38,10 @@ func TestManagedServerStatusCompact(t *testing.T) {
 
 func TestFormatStatusSummaryCompact(t *testing.T) {
 	b := &bridge{servers: map[string]*managedServer{}}
-	b.servers["grep"] = newManagedServer("grep", ServerConfig{}, log.New(io.Discard, "", 0))
+	b.servers["grep"] = newManagedServer("grep", ServerConfig{}, "", log.New(io.Discard, "", 0))
 	b.servers["grep"].state = stateReady
 	b.servers["grep"].tools = []mcp.Tool{{Name: "searchGitHub"}}
-	b.servers["n8n-mcp"] = newManagedServer("n8n-mcp", ServerConfig{}, log.New(io.Discard, "", 0))
+	b.servers["n8n-mcp"] = newManagedServer("n8n-mcp", ServerConfig{}, "", log.New(io.Discard, "", 0))
 	b.servers["n8n-mcp"].state = stateReady
 	b.servers["n8n-mcp"].tools = make([]mcp.Tool, 26)
 
@@ -54,7 +54,7 @@ func TestFormatStatusSummaryCompact(t *testing.T) {
 }
 
 func TestManagedServerStopBeforeStartDoesNotPanic(t *testing.T) {
-	s := newManagedServer("never-started", ServerConfig{}, log.New(io.Discard, "", 0))
+	s := newManagedServer("never-started", ServerConfig{}, "", log.New(io.Discard, "", 0))
 	s.stop()
 	if got, want := s.state, stateStopped; got != want {
 		t.Fatalf("state = %s, want %s", got, want)
@@ -98,10 +98,10 @@ func TestCompactErrShortensConnectionFailures(t *testing.T) {
 
 func TestNotifyLevelWarnOnPartialFailure(t *testing.T) {
 	b := &bridge{servers: map[string]*managedServer{}}
-	b.servers["grep"] = newManagedServer("grep", ServerConfig{}, log.New(io.Discard, "", 0))
+	b.servers["grep"] = newManagedServer("grep", ServerConfig{}, "", log.New(io.Discard, "", 0))
 	b.servers["grep"].state = stateReady
 	b.servers["grep"].tools = []mcp.Tool{{Name: "searchGitHub"}}
-	b.servers["broken"] = newManagedServer("broken", ServerConfig{}, log.New(io.Discard, "", 0))
+	b.servers["broken"] = newManagedServer("broken", ServerConfig{}, "", log.New(io.Discard, "", 0))
 	b.servers["broken"].state = stateError
 	b.servers["broken"].startErr = errors.New("authorization required\nmore detail")
 
@@ -114,7 +114,7 @@ func TestNotifyLevelWarnOnPartialFailure(t *testing.T) {
 }
 
 func TestStopDuringStartDiscardsStaleResult(t *testing.T) {
-	s := newManagedServer("racy", ServerConfig{}, log.New(io.Discard, "", 0))
+	s := newManagedServer("racy", ServerConfig{}, "", log.New(io.Discard, "", 0))
 
 	// Simulate the window inside start(): state is starting, gen recorded.
 	s.mu.Lock()
@@ -142,7 +142,7 @@ func TestStopDuringStartDiscardsStaleResult(t *testing.T) {
 }
 
 func TestCallToolNilClientReturnsErrorNotPanic(t *testing.T) {
-	s := newManagedServer("bogus", ServerConfig{Transport: "no-such-transport", RequestTimeout: 1, ConnectTimeout: 1}, log.New(io.Discard, "", 0))
+	s := newManagedServer("bogus", ServerConfig{Transport: "no-such-transport", RequestTimeout: 1, ConnectTimeout: 1}, "", log.New(io.Discard, "", 0))
 	_, err := s.callTool(context.Background(), "anything", nil)
 	if err == nil {
 		t.Fatal("expected error from unknown transport")
@@ -151,7 +151,7 @@ func TestCallToolNilClientReturnsErrorNotPanic(t *testing.T) {
 
 func TestPipeStderrKeepsLinesIntactAcrossChunks(t *testing.T) {
 	var buf bytes.Buffer
-	s := newManagedServer("srv", ServerConfig{}, log.New(&buf, "", 0))
+	s := newManagedServer("srv", ServerConfig{}, "", log.New(&buf, "", 0))
 
 	// iotest.OneByteReader forces 1-byte reads: the old 4096-byte
 	// chunking code would log every byte as its own "line".


### PR DESCRIPTION
## Summary
Fixes #68

Run stdio MCP server subprocesses from the active zot project directory instead of the installed `mcp-bridge` extension directory.

## Changes
- Thread the host/project cwd into managed MCP server instances
- Use mcp-go's stdio command factory hook to set `cmd.Dir` for spawned MCP servers
- Add a regression test that `loadServers` preserves the project cwd

## Test Plan
- Not run: Go toolchain is not installed in this cron environment (`go`/`gofmt` not found)
- Static sanity: inspected diff and balanced braces for changed Go files