### PR TITLE
tui: make tool-call arg width configurable via ZOT_TOOL_ARG_WIDTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,20 @@ ZOT_FLAT_TOOLS=0 zot   # boxes, even if config.json says "flat"
 
 Either way, theme colors still drive the rendering (the header uses your accent/foreground, output uses the tool-output color) and `ctrl+o` still expands a truncated result.
 
+### Tool arg width
+
+The header line for a tool call shows the tool name plus a one-line summary of its primary argument — a `path`, a `command`, or a query. That summary is truncated to 60 cells by default (`web_answer What is the best architecture to implement resilience wit...`). On a wide terminal that can clip long queries more than you'd like, so set the `ZOT_TOOL_ARG_WIDTH` env var to raise (or lower) the limit:
+
+```sh
+ZOT_TOOL_ARG_WIDTH=120 zot   # allow up to 120 cells before truncating
+```
+
+| Value | Effect |
+|---|---|
+| unset (default) | Truncate the arg summary at 60 cells. |
+| integer in `[20, 500]` | Truncate at that many cells instead. |
+| anything else | Ignored; falls back to the 60-cell default. |
+
 ## Compact input
 
 By default a message you send renders as a padded, background-tinted bubble: a blank tinted row above and below the text, with a `▌` accent bar down the left. So even a one-line prompt occupies three rows. Set `compact_input` to collapse it to a single quiet `▌ your text` gutter line per wrapped row — no padding rows, no background tint.

--- a/packages/tui/view.go
+++ b/packages/tui/view.go
@@ -2131,19 +2131,48 @@ func toolResultBlock(th Theme, text string, width int, color int) []string {
 	return out
 }
 
+// defaultToolArgWidth is the number of cells the tool-call header
+// truncates the primary argument (path/command/query) to when the
+// ZOT_TOOL_ARG_WIDTH environment variable is unset or invalid.
+const defaultToolArgWidth = 60
+
+// toolArgWidth returns the maximum cell width for the truncated
+// primary argument shown in a tool-call header. It defaults to
+// defaultToolArgWidth but can be raised or lowered with the
+// ZOT_TOOL_ARG_WIDTH environment variable, which is useful for wide
+// terminals where the default clips long queries too aggressively.
+// Values outside the sane range [20, 500] are ignored so a stray or
+// malformed setting can never produce an unreadable header or an
+// out-of-range slice.
+func toolArgWidth() int {
+	v := strings.TrimSpace(os.Getenv("ZOT_TOOL_ARG_WIDTH"))
+	if v == "" {
+		return defaultToolArgWidth
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 20 || n > 500 {
+		return defaultToolArgWidth
+	}
+	return n
+}
+
 // ShortArgs renders a tool call's arguments into a one-line
 // suffix for the "tool name <args>" header. tool is the tool
 // name so we can add shape-specific decorations: for read we
 // append the requested line range (e.g. "path:1-200") pulled
 // from the offset/limit args, which is useful context at a
 // glance without expanding the result body. Other tools keep
-// the legacy "path or command, truncated at 60 cells" shape.
+// the legacy "path or command, truncated" shape.
+//
+// The truncation width defaults to 60 cells but can be tuned via
+// the ZOT_TOOL_ARG_WIDTH environment variable (see toolArgWidth).
 //
 // Exported because the interactive mode pre-populates the
 // ToolCallView.Args field with this value as soon as the tool
 // call is announced, so the live overlay's header matches what
 // the finalised transcript will later render.
 func ShortArgs(tool string, raw json.RawMessage) string {
+	width := toolArgWidth()
 	var v any
 	if err := json.Unmarshal(raw, &v); err != nil {
 		return ""
@@ -2152,8 +2181,8 @@ func ShortArgs(tool string, raw json.RawMessage) string {
 	if !ok {
 		b, _ := json.Marshal(v)
 		s := oneLineToolLabel(string(b))
-		if len(s) > 60 {
-			s = s[:57] + "..."
+		if len(s) > width {
+			s = s[:width-3] + "..."
 		}
 		return s
 	}
@@ -2167,8 +2196,8 @@ func ShortArgs(tool string, raw json.RawMessage) string {
 	if primary == "" {
 		b, _ := json.Marshal(v)
 		s := oneLineToolLabel(string(b))
-		if len(s) > 60 {
-			s = s[:57] + "..."
+		if len(s) > width {
+			s = s[:width-3] + "..."
 		}
 		return s
 	}
@@ -2193,7 +2222,7 @@ func ShortArgs(tool string, raw json.RawMessage) string {
 
 	// Truncate the primary arg leaving room for the suffix so the
 	// range stays visible even on absurdly long paths.
-	max := 60 - len(suffix)
+	max := width - len(suffix)
 	if max < 10 {
 		max = 10
 	}

--- a/packages/tui/view_tool_arg_width_test.go
+++ b/packages/tui/view_tool_arg_width_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestToolArgWidthDefault(t *testing.T) {
+	t.Setenv("ZOT_TOOL_ARG_WIDTH", "")
+	if got := toolArgWidth(); got != defaultToolArgWidth {
+		t.Fatalf("toolArgWidth() with unset env = %d, want %d", got, defaultToolArgWidth)
+	}
+}
+
+func TestToolArgWidthEnvOverride(t *testing.T) {
+	t.Setenv("ZOT_TOOL_ARG_WIDTH", "120")
+	if got := toolArgWidth(); got != 120 {
+		t.Fatalf("toolArgWidth() = %d, want 120", got)
+	}
+}
+
+func TestToolArgWidthIgnoresInvalid(t *testing.T) {
+	cases := []string{"nope", "0", "10", "501", "-5", "12.5"}
+	for _, c := range cases {
+		t.Setenv("ZOT_TOOL_ARG_WIDTH", c)
+		if got := toolArgWidth(); got != defaultToolArgWidth {
+			t.Fatalf("toolArgWidth() with %q = %d, want default %d", c, got, defaultToolArgWidth)
+		}
+	}
+}
+
+func TestShortArgsTruncatesAtDefaultWidth(t *testing.T) {
+	t.Setenv("ZOT_TOOL_ARG_WIDTH", "")
+	long := strings.Repeat("a", 200)
+	raw := json.RawMessage(`{"command":"` + long + `"}`)
+	got := ShortArgs("web_answer", raw)
+	if len(got) != defaultToolArgWidth {
+		t.Fatalf("ShortArgs length = %d, want %d (%q)", len(got), defaultToolArgWidth, got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("ShortArgs should end with ellipsis, got %q", got)
+	}
+}
+
+func TestShortArgsRespectsWiderWidth(t *testing.T) {
+	t.Setenv("ZOT_TOOL_ARG_WIDTH", "120")
+	long := strings.Repeat("a", 200)
+	raw := json.RawMessage(`{"command":"` + long + `"}`)
+	got := ShortArgs("web_answer", raw)
+	if len(got) != 120 {
+		t.Fatalf("ShortArgs length = %d, want 120", len(got))
+	}
+}
+
+func TestShortArgsNoTruncationWhenShort(t *testing.T) {
+	t.Setenv("ZOT_TOOL_ARG_WIDTH", "120")
+	raw := json.RawMessage(`{"command":"short query"}`)
+	got := ShortArgs("web_answer", raw)
+	if got != "short query" {
+		t.Fatalf("ShortArgs = %q, want %q", got, "short query")
+	}
+}


### PR DESCRIPTION
# tui: make tool-call arg width configurable via `ZOT_TOOL_ARG_WIDTH`

## What

The tool-call header line renders the tool name plus a one-line summary of
the primary argument (`path` / `file_path` / `command`). `ShortArgs` in
`packages/tui/view.go` truncates that summary at a **hardcoded 60 cells**:

```
bash cd ~/some/very/very/very/very/long/path/ "=== gh a...
```

On a wide terminal that clips long queries more aggressively than necessary,
and there was no way to change it short of patching the source.

## Change

- Add a `toolArgWidth()` helper that reads the `ZOT_TOOL_ARG_WIDTH`
  environment variable, mirroring the existing `CellAspectRatio()` /
  `ZOT_CELL_ASPECT` pattern in the same package.
- Default remains **60**. Values are clamped to `[20, 500]`; anything
  malformed or out of range falls back to the default, so a stray setting
  can never produce an unreadable header or an out-of-range slice.
- Replace the three hardcoded `60`s in `ShortArgs` with the resolved width
  (and derive the ellipsis cutoff from it instead of the magic `57`).
- Document it under the **Tool rendering** section of the README.
- Add `view_tool_arg_width_test.go` covering the default, override,
  invalid-value fallback, and truncation behaviour.

## Usage

```sh
ZOT_TOOL_ARG_WIDTH=120 zot   # allow up to 120 cells before truncating
```

| Value | Effect |
|---|---|
| unset (default) | Truncate the arg summary at 60 cells. |
| integer in `[20, 500]` | Truncate at that many cells instead. |
| anything else | Ignored; falls back to the 60-cell default. |

## Testing

- `go test ./packages/tui/` — all pass (new tests + existing suite).
- `gofmt` clean.

No behaviour change unless the env var is set.
