### PR TITLE
Use XDG_STATE_HOME on all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ The easiest way is to just run `zot` and type `/login`. The TUI opens even witho
 3. `$ZOT_HOME/auth.json` (API key or OAuth token; mode 0600)
 
 `$ZOT_HOME` defaults to:
-- macOS: `~/Library/Application Support/zot`
-- Linux: `$XDG_STATE_HOME/zot` or `~/.local/state/zot`
-- Windows: `%LOCALAPPDATA%\zot`
+- All platforms: `$XDG_STATE_HOME/zot` when `XDG_STATE_HOME` is set
+- macOS fallback: `~/Library/Application Support/zot`
+- Linux fallback: `~/.local/state/zot`
+- Windows fallback: `%LOCALAPPDATA%\zot`
 
 ### `/login` flow
 
@@ -392,7 +393,7 @@ No configuration is required — the candidate list is built dynamically from yo
 
 ### Custom models
 
-Place a `models.json` in `$ZOT_HOME` (macOS: `~/Library/Application Support/zot/`, Linux: `~/.local/state/zot/`) to add models that aren't in the baked-in catalog or to override existing entries:
+Place a `models.json` in `$ZOT_HOME` (`$XDG_STATE_HOME/zot/` when set, otherwise the platform default above) to add models that aren't in the baked-in catalog or to override existing entries:
 
 ```json
 {

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -97,8 +97,9 @@ zot scans two directories on startup, in this order:
 2. **Global**: `$ZOT_HOME/extensions/<name>/extension.json`
 
 A project-local extension with the same name wins over a global one.
-On macOS `$ZOT_HOME` defaults to `~/Library/Application Support/zot/`;
-on Linux it's `$XDG_STATE_HOME/zot` or `~/.local/state/zot`.
+When `XDG_STATE_HOME` is set on any platform, `$ZOT_HOME` defaults to
+`$XDG_STATE_HOME/zot`. Otherwise it defaults to `~/Library/Application Support/zot/`
+on macOS, `~/.local/state/zot` on Linux, or `%LOCALAPPDATA%\zot` on Windows.
 
 Because each extension owns its own directory, the recommended place
 for extension state is inside that directory itself (for example

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -64,8 +64,9 @@ skill ecosystem works in zot unchanged. Drop your existing
 `.claude/skills/` or `.agents/skills/` directories into a project and
 zot will pick them up.
 
-`$ZOT_HOME` defaults to `~/Library/Application Support/zot/` on macOS,
-`$XDG_STATE_HOME/zot` on Linux, `%LOCALAPPDATA%\zot` on Windows.
+When `XDG_STATE_HOME` is set on any platform, `$ZOT_HOME` defaults to
+`$XDG_STATE_HOME/zot`. Otherwise it defaults to `~/Library/Application Support/zot/`
+on macOS, `~/.local/state/zot` on Linux, or `%LOCALAPPDATA%\zot` on Windows.
 
 ## Inspecting installed skills
 

--- a/examples/extensions/mcp-bridge/Makefile
+++ b/examples/extensions/mcp-bridge/Makefile
@@ -4,10 +4,10 @@ BIN := $(notdir $(CURDIR))
 # Must match "name" in extension.json (slash command/logical extension name).
 EXT := mcp
 ZOT_HOME ?= $(shell \
-	if [ "$$(uname -s)" = "Darwin" ]; then \
-		printf '%s/Library/Application Support/zot' "$$HOME"; \
-	elif [ -n "$$XDG_STATE_HOME" ]; then \
+	if [ -n "$$XDG_STATE_HOME" ]; then \
 		printf '%s/zot' "$$XDG_STATE_HOME"; \
+	elif [ "$$(uname -s)" = "Darwin" ]; then \
+		printf '%s/Library/Application Support/zot' "$$HOME"; \
 	else \
 		printf '%s/.local/state/zot' "$$HOME"; \
 	fi)

--- a/examples/extensions/mcp-bridge/README.md
+++ b/examples/extensions/mcp-bridge/README.md
@@ -61,7 +61,7 @@ Config files are loaded from two locations (project overrides global per-server)
 
 | Location | Scope |
 |---|---|
-| `$ZOT_HOME/mcp.json` | Global (macOS: `~/Library/Application Support/zot/mcp.json`) |
+| `$ZOT_HOME/mcp.json` | Global (`$XDG_STATE_HOME/zot/mcp.json` when `XDG_STATE_HOME` is set) |
 | `.zot/mcp.json` | Project-level (in your project root) |
 
 ### Config Format

--- a/examples/extensions/mcp-bridge/config.go
+++ b/examples/extensions/mcp-bridge/config.go
@@ -3,7 +3,7 @@
 // Reads standard MCP config files (same format as Claude Desktop, Cursor, etc.)
 // from two locations:
 //
-//  1. Global:  $ZOT_HOME/mcp.json  (macOS: ~/Library/Application Support/zot/mcp.json)
+//  1. Global:  $ZOT_HOME/mcp.json
 //  2. Project: .zot/mcp.json       (in the current working directory)
 //
 // Project config overrides global config per-server (shallow merge).

--- a/examples/extensions/mcp-bridge/config.go
+++ b/examples/extensions/mcp-bridge/config.go
@@ -47,6 +47,9 @@ func zotHome() string {
 	if h := os.Getenv("ZOT_HOME"); h != "" {
 		return h
 	}
+	if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "zot")
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		home, _ := os.UserHomeDir()
@@ -54,9 +57,6 @@ func zotHome() string {
 	case "windows":
 		return filepath.Join(os.Getenv("APPDATA"), "zot")
 	default: // linux, freebsd, etc.
-		if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
-			return filepath.Join(xdg, "zot")
-		}
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, ".local", "state", "zot")
 	}

--- a/packages/agent/config.go
+++ b/packages/agent/config.go
@@ -108,6 +108,9 @@ func ZotHome() string {
 	if v := os.Getenv("ZOT_HOME"); v != "" {
 		return v
 	}
+	if v := os.Getenv("XDG_STATE_HOME"); v != "" {
+		return filepath.Join(v, "zot")
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		if home, err := os.UserHomeDir(); err == nil {
@@ -117,9 +120,6 @@ func ZotHome() string {
 		if v := os.Getenv("LOCALAPPDATA"); v != "" {
 			return filepath.Join(v, "zot")
 		}
-	}
-	if v := os.Getenv("XDG_STATE_HOME"); v != "" {
-		return filepath.Join(v, "zot")
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		return filepath.Join(home, ".local", "state", "zot")

--- a/packages/agent/config_home_test.go
+++ b/packages/agent/config_home_test.go
@@ -1,0 +1,24 @@
+package agent
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestZotHomePrefersExplicitHomeOverXDGStateHome(t *testing.T) {
+	t.Setenv("ZOT_HOME", filepath.Join("explicit", "zot"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join("xdg", "state"))
+
+	if got, want := ZotHome(), filepath.Join("explicit", "zot"); got != want {
+		t.Fatalf("ZotHome() = %q, want %q", got, want)
+	}
+}
+
+func TestZotHomeUsesXDGStateHome(t *testing.T) {
+	t.Setenv("ZOT_HOME", "")
+	t.Setenv("XDG_STATE_HOME", filepath.Join("xdg", "state"))
+
+	if got, want := ZotHome(), filepath.Join("xdg", "state", "zot"); got != want {
+		t.Fatalf("ZotHome() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Check `XDG_STATE_HOME` first to determine zot's home on all platforms, if not set, use platform specific values. Inspired by https://becca.ooo/blog/macos-dotfiles/ - it would of course be possible to set `ZOT_HOME` directly, so this is more of a convenience change, but maybe worth considering.