### PR TITLE
Fix Google Vertex global endpoint

### DIFF
--- a/packages/provider/google_vertex.go
+++ b/packages/provider/google_vertex.go
@@ -311,7 +311,11 @@ func (t *vertexTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	newPath := fmt.Sprintf("/v1/projects/%s/locations/%s/publishers/google/models/%s%s",
 		t.cfg.project, t.cfg.location, modelID, verb)
 	clone := req.Clone(req.Context())
-	clone.URL.Host = t.cfg.location + "-aiplatform.googleapis.com"
+	if t.cfg.location == "global" {
+		clone.URL.Host = "aiplatform.googleapis.com"
+	} else {
+		clone.URL.Host = t.cfg.location + "-aiplatform.googleapis.com"
+	}
 	clone.URL.Path = newPath
 	// Drop existing auth header and pick the right one.
 	clone.Header.Del("x-goog-api-key")
@@ -336,9 +340,13 @@ func NewVertex(_ string, _ string) Client {
 	if err != nil {
 		return &unimplementedClient{name: "google-vertex", hint: err.Error()}
 	}
+	baseHost := "aiplatform.googleapis.com"
+	if cfg.location != "global" {
+		baseHost = cfg.location + "-aiplatform.googleapis.com"
+	}
 	inner := &geminiClient{
 		apiKey:  "vertex-placeholder", // overwritten by transport
-		baseURL: "https://" + cfg.location + "-aiplatform.googleapis.com",
+		baseURL: "https://" + baseHost,
 		http: &http.Client{
 			Transport: &vertexTransport{inner: http.DefaultTransport, cfg: cfg},
 			Timeout:   0,

--- a/packages/provider/google_vertex_test.go
+++ b/packages/provider/google_vertex_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,6 +38,55 @@ func TestVertexConfigParsesAuthorizedUser(t *testing.T) {
 	}
 	if cfg.cacheKey() != "user:fake.apps.googleusercontent.com" {
 		t.Errorf("cacheKey = %q", cfg.cacheKey())
+	}
+}
+
+type vertexRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f vertexRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestVertexTransportEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		wantHost string
+	}{
+		{name: "global", location: "global", wantHost: "aiplatform.googleapis.com"},
+		{name: "regional", location: "us-central1", wantHost: "us-central1-aiplatform.googleapis.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *http.Request
+			transport := &vertexTransport{
+				cfg: &vertexConfig{
+					project:  "test-project",
+					location: tt.location,
+					apiKey:   "test-key",
+				},
+				inner: vertexRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+					got = req
+					return &http.Response{StatusCode: http.StatusOK}, nil
+				}),
+			}
+			req, err := http.NewRequest(http.MethodPost, "https://placeholder.example/v1beta/models/gemini-test:streamGenerateContent?alt=sse", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := transport.RoundTrip(req); err != nil {
+				t.Fatalf("RoundTrip: %v", err)
+			}
+			if got.URL.Host != tt.wantHost {
+				t.Errorf("host = %q, want %q", got.URL.Host, tt.wantHost)
+			}
+			wantPath := "/v1/projects/test-project/locations/" + tt.location + "/publishers/google/models/gemini-test:streamGenerateContent"
+			if got.URL.Path != wantPath {
+				t.Errorf("path = %q, want %q", got.URL.Path, wantPath)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
For the global GCP endpoint, the URL is contructed starting with https://aiplatform.googleapis.com/ instead of
https://${GOOGLE_CLOUD_LOCATION}-aiplatform.googleapis.com.

See also https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations#rest