### PR TITLE
Prevent redirect errors for GitHub enterprise accounts

### DIFF
--- a/packages/provider/github_copilot.go
+++ b/packages/provider/github_copilot.go
@@ -175,6 +175,7 @@ func (t *copilotRefreshTransport) RoundTrip(req *http.Request) (*http.Response, 
 		if u, err := url.Parse(tok.baseURL); err == nil && u.Host != clone.URL.Host {
 			clone.URL.Scheme = u.Scheme
 			clone.URL.Host = u.Host
+			clone.Host = u.Host
 		}
 	}
 	return t.inner.RoundTrip(clone)

--- a/packages/provider/github_copilot_test.go
+++ b/packages/provider/github_copilot_test.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+type mockRoundTripper struct {
+	lastReq *http.Request
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.lastReq = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func TestCopilotHostRewrite(t *testing.T) {
+	// Seed the cache with a mock token that carries a non-default proxy endpoint
+	// Ensure the expiresAt time is far in the future so that it bypasses the exchange check
+	const pat = "ghp_mock_token_for_test"
+	copilotCache.mu.Lock()
+	copilotCache.tokens[pat] = copilotToken{
+		value:     "mock-jwt-with;proxy-ep=enterprise.copilot.proxy",
+		expiresAt: time.Now().Add(1 * time.Hour),
+		baseURL:   "https://api.enterprise.copilot.proxy",
+	}
+	copilotCache.mu.Unlock()
+
+	mockRT := &mockRoundTripper{}
+	transport := &copilotRefreshTransport{
+		inner: mockRT,
+		pat:   pat,
+	}
+
+	reqUrl, err := url.Parse("https://api.individual.githubcopilot.com/chat/completions")
+	if err != nil {
+		t.Fatalf("failed to parse test URL: %v", err)
+	}
+
+	req := &http.Request{
+		Method: "POST",
+		URL:    reqUrl,
+		Header: make(http.Header),
+	}
+	req = req.WithContext(context.Background())
+
+	_, err = transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip failed: %v", err)
+	}
+
+	if mockRT.lastReq == nil {
+		t.Fatal("RoundTrip did not forward the request")
+	}
+
+	// Verify both URL host and Host header are rewritten correctly to prevent 421 Misdirected Request
+	wantHost := "api.enterprise.copilot.proxy"
+	if mockRT.lastReq.URL.Host != wantHost {
+		t.Errorf("expected URL.Host to be %q, got %q", wantHost, mockRT.lastReq.URL.Host)
+	}
+	if mockRT.lastReq.Host != wantHost {
+		t.Errorf("expected Host header (Request.Host) to be %q, got %q", wantHost, mockRT.lastReq.Host)
+	}
+}


### PR DESCRIPTION
Replace the host for the GitHub Copilot endpoint with the value from the token after token exchange is completed.