### PR TITLE
Make auto-compact threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Slash command names are case-insensitive in the TUI and messaging backends; argu
 | `/unjail` | Allow tools to touch paths outside again. |
 | `/reload-ext` | Hot-reload all extensions (re-read manifests, respawn subprocesses, rebuild tool registry). |
 | `/telegram` | Connect, disconnect, or show status of the Telegram bridge (takes `connect` / `disconnect` / `status` as an optional argument; opens a picker without one). When connected, DMs from the paired user become prompts in the running session and the assistant's replies are mirrored back to Telegram. Alias: `/tg`. |
-| `/settings` | Toggle persistent settings (inline images, auto-swarm) with `enter`/`space`. Saved to `$ZOT_HOME/config.json`; takes effect immediately. |
+| `/settings` | Change persistent settings, including inline images, auto-swarm, and the auto-compact threshold. Saved to `$ZOT_HOME/config.json`; takes effect immediately. |
 | `/clear` | Clear the chat transcript. |
 | `/exit` | Exit zot. |
 
@@ -378,6 +378,7 @@ Opens a dialog with every persistent setting. `up`/`down` to navigate, `enter` o
 
 - **render images when supported** — draw screenshots / `read`-returned images inline using the terminal's image protocol, or fall back to a text placeholder. Auto-detected from `TERM_PROGRAM`; the toggle overrides the detection. The row is greyed out and forced off on terminals that don't speak any image protocol.
 - **auto-swarm** — let the main agent spawn background sub-agents in parallel via a built-in `swarm_spawn` tool. Off by default. When on, the tool is registered with the running agent, the system prompt gains a short addendum telling the model to delegate independent sub-tasks proactively, and zot watches every sub-agent the main agent spawns. As soon as the last sub-agent in a batch finishes its initial task, an `[auto-swarm update]` message is injected back into the chat with each agent's status / task / transcript tail, so the main agent can summarise the collective outcome. Flipping off mid-session removes the tool from the live agent and strips the addendum on the next turn — the model stops trying to delegate. See `/swarm` for the dashboard that lets you monitor, message, kill, or remove the spawned agents.
+- **auto-compact threshold** — choose `off`, `70%`, `80%`, `85%` (default), or `90%` of the model's advertised context window. The selected percentage controls automatic compaction before and after interactive turns and persists as `auto_compact_threshold`. `off` disables percentage-based triggers but keeps manual `/compact` and automatic recovery from payload-too-large responses.
 - **jail new sessions by default**: start every new agent with tools confined to its working directory. Off by default. The setting applies to interactive, print, JSON, RPC, and background-agent runs, persists as `jail_by_default`, and immediately updates the current interactive session. `/jail` and `/unjail` remain session-scoped overrides and do not change this default.
 - **compact transcript rendering**: reduce visual chrome in the chat transcript. Tool calls render as a quiet header plus indented output instead of a bordered box, and sent messages render without padded background bubbles. Off by default. Changes apply immediately and persist to `config.json` as `compact_mode`.
 - **show loaded resources at startup**: list loaded `AGENTS.md` paths, extensions, and user-installed skills in compact sections above the transcript. Built-in skills are omitted. Off by default. Changes apply immediately and persist to `config.json` as `show_instructions_at_startup`.
@@ -394,7 +395,7 @@ Opens a picker listing every discovered SKILL.md file, built-ins hidden. Each ro
 
 Sends the current transcript through the model with a structured summarization prompt. The returned summary replaces the transcript as one synthetic user message, with the last few exchanges kept verbatim for continuity. The status bar's context meter resets. Use it when the context meter creeps past ~80%.
 
-zot also auto-compacts in the background: after any turn that leaves context usage at or above **85%** of the model's window, the agent kicks off a condense pass on its own. You'll see `condensing history, esc to cancel` above the status bar and an `(auto)` tag next to the context percentage; `esc` aborts it without touching the transcript.
+zot also auto-compacts in the background: after any turn that reaches the configured context threshold, the agent kicks off a condense pass on its own. Choose `off`, `70%`, `80%`, `85%` (default), or `90%` under `/settings` → **auto-compact threshold**. You'll see `condensing history, esc to cancel` above the status bar and an `(auto)` tag next to the context percentage; `esc` aborts it without touching the transcript. Turning the percentage trigger off does not disable automatic compaction and retry after a payload-too-large response.
 
 ### `/jail`
 

--- a/docs/superpowers/plans/2026-07-28-configurable-auto-compact-threshold.md
+++ b/docs/superpowers/plans/2026-07-28-configurable-auto-compact-threshold.md
@@ -1,0 +1,239 @@
+# Configurable Auto-Compact Threshold Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persisted auto-compaction threshold presets to the interactive TUI settings.
+
+**Architecture:** Keep automatic triggering in `packages/agent/modes`. Thread an optional integer percentage from persisted `agent.Config` into `modes.InteractiveConfig`, normalize missing or invalid values to 85%, and let zero disable only percentage-based triggers. Reuse the settings dialog's existing fixed-option picker and settings-store persistence path.
+
+**Tech Stack:** Go, standard library, Zot's existing TUI settings dialog, JSON configuration.
+
+## Global Constraints
+
+- Supported values are `0` (off), `70`, `80`, `85`, and `90`.
+- Missing or invalid persisted values resolve to `85`.
+- Disabling the threshold does not disable manual compaction or HTTP 413 recovery.
+- Do not add dependencies or change non-interactive compaction behavior.
+- Preserve unrelated working-tree changes and stage only this feature.
+
+---
+
+### Task 1: Configuration and threshold decision
+
+**Files:**
+- Modify: `packages/agent/config.go`
+- Modify: `packages/agent/modes/interactive.go`
+- Create: `packages/agent/modes/auto_compact_test.go`
+- Modify: `packages/agent/cli.go`
+
+**Interfaces:**
+- Produces: `Config.AutoCompactThreshold *int`
+- Produces: `InteractiveConfig.AutoCompactThreshold *int`
+- Produces: `normalizeAutoCompactThreshold(*int) int`
+- Produces: `shouldAutoCompact(inputTokens, contextWindow, thresholdPercent int) bool`
+
+- [ ] **Step 1: Write failing normalization and decision tests**
+
+Add table-driven tests proving nil and invalid values resolve to 85, supported presets survive unchanged, zero disables percentage checks, and 70/80/85/90 trigger exactly at their boundaries.
+
+```go
+func TestNormalizeAutoCompactThreshold(t *testing.T) {
+	tests := []struct {
+		name string
+		value *int
+		want int
+	}{
+		{name: "missing", value: nil, want: 85},
+		{name: "off", value: intPtr(0), want: 0},
+		{name: "seventy", value: intPtr(70), want: 70},
+		{name: "invalid", value: intPtr(42), want: 85},
+	}
+	// Assert normalizeAutoCompactThreshold(test.value) == test.want.
+}
+
+func TestShouldAutoCompactUsesConfiguredThreshold(t *testing.T) {
+	if shouldAutoCompact(84, 100, 85) {
+		t.Fatal("84% must remain below an 85% threshold")
+	}
+	if !shouldAutoCompact(85, 100, 85) {
+		t.Fatal("85% must trigger an 85% threshold")
+	}
+	if shouldAutoCompact(100, 100, 0) {
+		t.Fatal("off must disable percentage-triggered compaction")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```sh
+go test ./packages/agent/modes -run 'TestNormalizeAutoCompactThreshold|TestShouldAutoCompactUsesConfiguredThreshold' -count=1
+```
+
+Expected: compilation failure because the normalization and decision helpers do not exist.
+
+- [ ] **Step 3: Add optional configuration and minimal helpers**
+
+Add `AutoCompactThreshold *int` with JSON name `auto_compact_threshold` to both configuration structs. Implement normalization for exactly `0`, `70`, `80`, `85`, and `90`, defaulting all other values to `85`. Replace the hard-coded fraction check with the normalized percentage helper and pass the config field through `cli.go`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```sh
+go test ./packages/agent/modes -run 'TestNormalizeAutoCompactThreshold|TestShouldAutoCompactUsesConfiguredThreshold' -count=1
+```
+
+Expected: PASS.
+
+### Task 2: Persistence and TUI preset picker
+
+**Files:**
+- Modify: `packages/agent/settings_store.go`
+- Modify: `packages/agent/settings_store_test.go`
+- Modify: `packages/agent/modes/interactive.go`
+- Modify: `packages/agent/modes/auto_compact_test.go`
+
+**Interfaces:**
+- Extends: `SettingsStore.SetAutoCompactThreshold(percent int) error`
+- Consumes: `normalizeAutoCompactThreshold(*int) int`
+
+- [ ] **Step 1: Write failing persistence and settings-item tests**
+
+Add a settings-store test that writes `70` into an isolated `$ZOT_HOME` and verifies `auto_compact_threshold` plus an unrelated config field. Add a modes test that opens settings with missing configuration and verifies the option values are `0`, `70`, `80`, `85`, `90` with `85` selected.
+
+```go
+func TestConfigSettingsStorePersistsAutoCompactThreshold(t *testing.T) {
+	t.Setenv("ZOT_HOME", t.TempDir())
+	if err := SaveConfig(Config{Theme: "dark"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (configSettingsStore{}).SetAutoCompactThreshold(70); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AutoCompactThreshold == nil || *cfg.AutoCompactThreshold != 70 {
+		t.Fatalf("auto_compact_threshold = %v, want 70", cfg.AutoCompactThreshold)
+	}
+	if cfg.Theme != "dark" {
+		t.Fatalf("unrelated config changed: theme = %q, want dark", cfg.Theme)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```sh
+go test ./packages/agent ./packages/agent/modes -run 'AutoCompactThreshold|SettingsDialog.*AutoCompact' -count=1
+```
+
+Expected: compilation or assertion failure because persistence and the picker row do not exist.
+
+- [ ] **Step 3: Implement persistence and live setting application**
+
+Add the settings-store method, fixed picker options, choice resolution, action routing, integer parsing, live `InteractiveConfig` update, and status message. Persist only values exposed by the picker; normalize the live value defensively before use.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```sh
+go test ./packages/agent ./packages/agent/modes -run 'AutoCompactThreshold|SettingsDialog.*AutoCompact' -count=1
+```
+
+Expected: PASS.
+
+### Task 3: Documentation and full verification
+
+**Files:**
+- Modify: `README.md`
+- Review: `docs/superpowers/specs/2026-07-28-configurable-auto-compact-threshold-design.md`
+- Review: `docs/superpowers/plans/2026-07-28-configurable-auto-compact-threshold.md`
+
+**Interfaces:**
+- Documents: `auto_compact_threshold`
+- Documents: `/settings` presets and `off` semantics
+
+- [ ] **Step 1: Update user documentation**
+
+Document `off`, `70%`, `80%`, `85%` default, and `90%` in the `/settings` section. Update `/compact` to state that threshold-based auto-compaction is configurable and that payload-too-large recovery remains active when the percentage trigger is off.
+
+- [ ] **Step 2: Format changed Go files**
+
+Run:
+
+```sh
+gofmt -w packages/agent/config.go packages/agent/settings_store.go packages/agent/settings_store_test.go packages/agent/cli.go packages/agent/modes/interactive.go packages/agent/modes/auto_compact_test.go
+```
+
+- [ ] **Step 3: Run the complete test suite**
+
+Run:
+
+```sh
+go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run static analysis**
+
+Run:
+
+```sh
+go vet ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect the final change**
+
+Run:
+
+```sh
+git diff --check
+git status --short
+git diff
+```
+
+Confirm only the configuration, TUI, tests, README, design, and plan belong to the feature.
+
+### Task 4: Publish the pull request
+
+**Files:**
+- Stage only the files listed in Tasks 1-3.
+
+**Interfaces:**
+- Produces: branch `codex/configurable-auto-compact-threshold`
+- Produces: one feature commit and a ready GitHub pull request
+
+- [ ] **Step 1: Create the feature branch**
+
+```sh
+git switch -c codex/configurable-auto-compact-threshold
+```
+
+- [ ] **Step 2: Stage explicit feature paths and review**
+
+Stage only the implementation, tests, README, design, and plan. Review `git diff --cached --check` and `git diff --cached`.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git commit -m "Make auto-compact threshold configurable"
+```
+
+- [ ] **Step 4: Push the branch**
+
+Push to the appropriate writable GitHub remote with upstream tracking.
+
+- [ ] **Step 5: Open a ready pull request**
+
+Target the upstream default branch. Include the behavior, compatibility, user impact, and exact validation commands in the PR body.

--- a/docs/superpowers/specs/2026-07-28-configurable-auto-compact-threshold-design.md
+++ b/docs/superpowers/specs/2026-07-28-configurable-auto-compact-threshold-design.md
@@ -1,0 +1,73 @@
+# Configurable Auto-Compact Threshold
+
+## Goal
+
+Let users choose when Zot automatically compacts an interactive transcript from the existing `/settings` dialog, while preserving the current 85% behavior by default.
+
+## User Experience
+
+Add a top-level `/settings` option named **auto-compact threshold** with these choices:
+
+- `off`
+- `70%`
+- `80%`
+- `85%` (default)
+- `90%`
+
+Changing the option takes effect for the next turn without restarting Zot.
+
+The `off` choice disables context-percentage triggers before and after turns. It does not disable:
+
+- manual `/compact`
+- explicit RPC or SDK compaction
+- automatic compaction and retry after an HTTP 413 or equivalent payload-too-large response
+
+## Configuration
+
+Persist the selected percentage in `$ZOT_HOME/config.json` as:
+
+```json
+{
+  "auto_compact_threshold": 85
+}
+```
+
+The field is an optional integer percentage:
+
+- A missing field resolves to `85` for backward compatibility.
+- `0` represents `off`.
+- Valid non-zero values are `70`, `80`, `85`, and `90`.
+- Any other persisted value resolves to `85` at runtime.
+- When a user selects a setting in the TUI, Zot writes only one of the supported values.
+
+## Implementation Boundaries
+
+The interactive host continues to own automatic triggering. `core.Agent.Compact`, RPC, SDK, bot, print, and JSON mode behavior remain unchanged.
+
+Replace the hard-coded `0.85` comparison with a helper that resolves the configured integer percentage and compares the most recent context usage against the model's advertised context window. A resolved value of `0` returns false for percentage-based checks.
+
+The payload-too-large recovery path continues to invoke automatic compaction independently of the configured percentage.
+
+The settings dialog uses its existing fixed-option picker. No free-form numeric input or new dialog control is introduced.
+
+## Error Handling
+
+Configuration writes use the existing settings-store error path and show failures in the TUI status area. An invalid value already present in `config.json` does not prevent startup; Zot falls back to 85%.
+
+## Tests
+
+Add focused tests covering:
+
+- missing configuration resolves to 85%
+- every supported preset resolves correctly
+- invalid persisted values resolve to 85%
+- `off` suppresses percentage-triggered compaction
+- threshold comparison uses the selected percentage
+- the settings store persists the selected integer
+- the settings dialog exposes all presets with 85% selected by default
+
+Run the focused package tests during development, then `gofmt`, `go test ./...`, `go vet ./...`, `git diff --check`, and final status/diff inspection.
+
+## Documentation
+
+Update the README sections for `/settings` and `/compact` to list the presets, default, immediate application, and the fact that `off` does not disable payload-too-large recovery.

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -989,6 +989,7 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		Theme:                      theme,
 		InlineImagesEnabled:        initialCfg.InlineImagesEnabled,
 		AutoSwarmEnabled:           initialCfg.AutoSwarmEnabled,
+		AutoCompactThreshold:       initialCfg.AutoCompactThreshold,
 		JailByDefault:              initialCfg.JailByDefault,
 		QuickModelShortcuts:        quickModelShortcuts,
 		RecursiveFileSuggest:       initialCfg.RecursiveFileSuggest,

--- a/packages/agent/config.go
+++ b/packages/agent/config.go
@@ -58,6 +58,11 @@ type Config struct {
 	// default; nil/missing means disabled. Toggle from /settings.
 	AutoSwarmEnabled *bool `json:"auto_swarm_enabled,omitempty"`
 
+	// AutoCompactThreshold is the percentage of the model context window
+	// that triggers automatic transcript compaction in interactive mode.
+	// nil/missing means 85; zero disables percentage-based triggers.
+	AutoCompactThreshold *int `json:"auto_compact_threshold,omitempty"`
+
 	// JailByDefault confines tools to the session working directory when
 	// a new agent starts. Off by default; nil/missing means disabled.
 	// The live session can still override this with /jail or /unjail.

--- a/packages/agent/modes/auto_compact_test.go
+++ b/packages/agent/modes/auto_compact_test.go
@@ -1,0 +1,90 @@
+package modes
+
+import "testing"
+
+func TestNormalizeAutoCompactThreshold(t *testing.T) {
+	tests := []struct {
+		name  string
+		value *int
+		want  int
+	}{
+		{name: "missing", value: nil, want: 85},
+		{name: "off", value: autoCompactIntPtr(0), want: 0},
+		{name: "seventy", value: autoCompactIntPtr(70), want: 70},
+		{name: "eighty", value: autoCompactIntPtr(80), want: 80},
+		{name: "eighty five", value: autoCompactIntPtr(85), want: 85},
+		{name: "ninety", value: autoCompactIntPtr(90), want: 90},
+		{name: "invalid low", value: autoCompactIntPtr(42), want: 85},
+		{name: "invalid high", value: autoCompactIntPtr(100), want: 85},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeAutoCompactThreshold(tt.value); got != tt.want {
+				t.Fatalf("normalizeAutoCompactThreshold(%v) = %d, want %d", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldAutoCompactUsesConfiguredThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		used      int
+		window    int
+		threshold int
+		want      bool
+	}{
+		{name: "below threshold", used: 84, window: 100, threshold: 85, want: false},
+		{name: "at threshold", used: 85, window: 100, threshold: 85, want: true},
+		{name: "above threshold", used: 86, window: 100, threshold: 85, want: true},
+		{name: "seventy percent preset", used: 70, window: 100, threshold: 70, want: true},
+		{name: "eighty percent preset", used: 80, window: 100, threshold: 80, want: true},
+		{name: "ninety percent preset", used: 90, window: 100, threshold: 90, want: true},
+		{name: "off", used: 100, window: 100, threshold: 0, want: false},
+		{name: "missing usage", used: 0, window: 100, threshold: 85, want: false},
+		{name: "missing window", used: 85, window: 0, threshold: 85, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldAutoCompact(tt.used, tt.window, tt.threshold); got != tt.want {
+				t.Fatalf("shouldAutoCompact(%d, %d, %d) = %t, want %t", tt.used, tt.window, tt.threshold, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSettingsDialogOffersAutoCompactThresholdPresets(t *testing.T) {
+	interactive := NewInteractive(InteractiveConfig{})
+	interactive.openSettingsDialog()
+
+	var thresholdItem *settingsItem
+	for idx := range interactive.settingsDialog.items {
+		item := &interactive.settingsDialog.items[idx]
+		if item.key == "auto_compact_threshold" {
+			thresholdItem = item
+			break
+		}
+	}
+	if thresholdItem == nil {
+		t.Fatal("settings dialog is missing auto-compact threshold")
+	}
+
+	wantValues := []string{"0", "70", "80", "85", "90"}
+	if len(thresholdItem.options) != len(wantValues) {
+		t.Fatalf("auto-compact options = %d, want %d", len(thresholdItem.options), len(wantValues))
+	}
+	for idx, want := range wantValues {
+		if got := thresholdItem.options[idx].value; got != want {
+			t.Fatalf("auto-compact option %d = %q, want %q", idx, got, want)
+		}
+	}
+	if got := thresholdItem.options[thresholdItem.choice].value; got != "85" {
+		t.Fatalf("default auto-compact choice = %q, want 85", got)
+	}
+}
+
+func autoCompactIntPtr(value int) *int {
+	return &value
+}

--- a/packages/agent/modes/auto_compact_test.go
+++ b/packages/agent/modes/auto_compact_test.go
@@ -85,6 +85,65 @@ func TestSettingsDialogOffersAutoCompactThresholdPresets(t *testing.T) {
 	}
 }
 
+func TestApplyAutoCompactThresholdSynchronizesLiveUpdate(t *testing.T) {
+	initialThreshold := 85
+	releaseStore := make(chan struct{})
+	store := &blockingAutoCompactSettingsStore{
+		entered: make(chan int, 1),
+		release: releaseStore,
+	}
+	interactive := NewInteractive(InteractiveConfig{
+		AutoCompactThreshold: &initialThreshold,
+		SettingsStore:        store,
+	})
+
+	interactive.mu.Lock()
+	locked := true
+	released := false
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		interactive.applyAutoCompactThresholdSetting("70")
+	}()
+	defer func() {
+		if !released {
+			close(releaseStore)
+		}
+		if locked {
+			interactive.mu.Unlock()
+		}
+		<-done
+	}()
+
+	if got := <-store.entered; got != 70 {
+		t.Fatalf("persisted threshold = %d, want 70", got)
+	}
+	if got := *interactive.cfg.AutoCompactThreshold; got != 85 {
+		t.Fatalf("threshold changed without holding Interactive.mu: got %d, want 85", got)
+	}
+
+	close(releaseStore)
+	released = true
+	interactive.mu.Unlock()
+	locked = false
+	<-done
+	if got := *interactive.cfg.AutoCompactThreshold; got != 70 {
+		t.Fatalf("threshold after setting completes = %d, want 70", got)
+	}
+}
+
+type blockingAutoCompactSettingsStore struct {
+	SettingsStore
+	entered chan int
+	release <-chan struct{}
+}
+
+func (s *blockingAutoCompactSettingsStore) SetAutoCompactThreshold(percent int) error {
+	s.entered <- percent
+	<-s.release
+	return nil
+}
+
 func autoCompactIntPtr(value int) *int {
 	return &value
 }

--- a/packages/agent/modes/interactive.go
+++ b/packages/agent/modes/interactive.go
@@ -3395,7 +3395,6 @@ func (i *Interactive) applyAutoCompactThresholdSetting(value string) {
 		return
 	}
 	threshold = normalizeAutoCompactThreshold(&threshold)
-	i.cfg.AutoCompactThreshold = &threshold
 	if store, ok := i.cfg.SettingsStore.(autoCompactThresholdSettingsStore); ok {
 		if err := store.SetAutoCompactThreshold(threshold); err != nil {
 			i.mu.Lock()
@@ -3405,6 +3404,7 @@ func (i *Interactive) applyAutoCompactThresholdSetting(value string) {
 		}
 	}
 	i.mu.Lock()
+	i.cfg.AutoCompactThreshold = &threshold
 	if threshold == 0 {
 		i.statusOK = "auto-compact threshold off"
 	} else {

--- a/packages/agent/modes/interactive.go
+++ b/packages/agent/modes/interactive.go
@@ -62,6 +62,11 @@ type InteractiveConfig struct {
 	// re-reading config.json on every open.
 	AutoSwarmEnabled *bool
 
+	// AutoCompactThreshold is the context-window percentage that triggers
+	// automatic compaction. nil means 85; zero disables percentage-based
+	// triggers while preserving payload-too-large recovery.
+	AutoCompactThreshold *int
+
 	// JailByDefault mirrors the persisted jail_by_default preference.
 	// The current sandbox may differ after a session-scoped /jail or /unjail.
 	JailByDefault *bool
@@ -320,6 +325,10 @@ type SettingsStore interface {
 
 type showInstructionsSettingsStore interface {
 	SetShowInstructionsAtStartup(enabled bool) error
+}
+
+type autoCompactThresholdSettingsStore interface {
+	SetAutoCompactThreshold(percent int) error
 }
 
 type Interactive struct {
@@ -3151,6 +3160,22 @@ func (i *Interactive) openSettingsDialog() {
 	workingPosition := tui.NormalizeWorkingPosition(i.cfg.TUIWorkingPosition)
 	quickItems := i.quickModelSettingItems()
 
+	autoCompactOptions := []settingsOption{
+		{value: "0", label: "off", desc: "disable context-percentage triggers; payload-too-large recovery stays enabled"},
+		{value: "70", label: "70%", desc: "compact earlier to keep more context headroom"},
+		{value: "80", label: "80%", desc: "compact with moderate context headroom"},
+		{value: "85", label: "85%", desc: "default balance between history and headroom"},
+		{value: "90", label: "90%", desc: "retain more history before compacting"},
+	}
+	autoCompactThreshold := normalizeAutoCompactThreshold(i.cfg.AutoCompactThreshold)
+	autoCompactChoice := 0
+	for idx, opt := range autoCompactOptions {
+		if opt.value == strconv.Itoa(autoCompactThreshold) {
+			autoCompactChoice = idx
+			break
+		}
+	}
+
 	reasoningOptions := []settingsOption{
 		{value: "", label: "off", desc: "no reasoning"},
 		{value: "minimum", label: "minimum", desc: "very brief (~1k tokens)"},
@@ -3252,6 +3277,13 @@ func (i *Interactive) openSettingsDialog() {
 			hint:     autoSwarmHint,
 		},
 		{
+			key:     "auto_compact_threshold",
+			label:   "auto-compact threshold",
+			desc:    "choose how full the model context can get before zot condenses conversation history",
+			options: autoCompactOptions,
+			choice:  autoCompactChoice,
+		},
+		{
 			key:   "jail_by_default",
 			label: "jail new sessions by default",
 			desc:  "confine tools to the session working directory unless /unjail is used",
@@ -3344,6 +3376,8 @@ func (i *Interactive) applySettingChange(act settingsAction) {
 		i.applyReasoningSetting(act.StringValue)
 	case act.Key == "theme":
 		i.applyThemeSetting(act.StringValue)
+	case act.Key == "auto_compact_threshold":
+		i.applyAutoCompactThresholdSetting(act.StringValue)
 	case act.Key == "tui_input_style":
 		i.applyTUIInputStyleSetting(act.StringValue)
 	case act.Key == "tui_status_position":
@@ -3353,6 +3387,32 @@ func (i *Interactive) applySettingChange(act settingsAction) {
 	default:
 		i.applySettingToggle(act.Key, act.Value)
 	}
+}
+
+func (i *Interactive) applyAutoCompactThresholdSetting(value string) {
+	threshold, err := strconv.Atoi(value)
+	if err != nil {
+		return
+	}
+	threshold = normalizeAutoCompactThreshold(&threshold)
+	i.cfg.AutoCompactThreshold = &threshold
+	if store, ok := i.cfg.SettingsStore.(autoCompactThresholdSettingsStore); ok {
+		if err := store.SetAutoCompactThreshold(threshold); err != nil {
+			i.mu.Lock()
+			i.statusErr = "settings: " + err.Error()
+			i.mu.Unlock()
+			return
+		}
+	}
+	i.mu.Lock()
+	if threshold == 0 {
+		i.statusOK = "auto-compact threshold off"
+	} else {
+		i.statusOK = fmt.Sprintf("auto-compact threshold %d%%", threshold)
+	}
+	i.statusErr = ""
+	i.mu.Unlock()
+	i.invalidate()
 }
 
 func (i *Interactive) quickModelSettingItems() []settingsItem {
@@ -5561,11 +5621,26 @@ func isPayloadTooLargeError(err error) bool {
 	return strings.Contains(msg, "http 413") || strings.Contains(msg, " 413") || strings.HasPrefix(msg, "413 ") || strings.Contains(msg, "payload too large") || strings.Contains(msg, "request entity too large")
 }
 
-// autoCompactThreshold is the context-window fraction at which the
-// agent will auto-compact after a turn ends. 0.85 leaves enough
-// headroom for one more user prompt + response before we bump the
-// hard limit.
-const autoCompactThreshold = 0.85
+const defaultAutoCompactThreshold = 85
+
+func normalizeAutoCompactThreshold(threshold *int) int {
+	if threshold == nil {
+		return defaultAutoCompactThreshold
+	}
+	switch *threshold {
+	case 0, 70, 80, 85, 90:
+		return *threshold
+	default:
+		return defaultAutoCompactThreshold
+	}
+}
+
+func shouldAutoCompact(inputTokens, contextWindow, thresholdPercent int) bool {
+	if inputTokens <= 0 || contextWindow <= 0 || thresholdPercent <= 0 {
+		return false
+	}
+	return float64(inputTokens)/float64(contextWindow) >= float64(thresholdPercent)/100
+}
 
 // shouldAutoCompactLocked reports whether the last turn pushed context
 // usage past the auto-compact threshold. Must be called with i.mu
@@ -5581,10 +5656,8 @@ func (i *Interactive) shouldAutoCompactLocked() bool {
 	if err != nil || m.ContextWindow <= 0 {
 		return false
 	}
-	if i.lastCtxInput <= 0 {
-		return false
-	}
-	return float64(i.lastCtxInput)/float64(m.ContextWindow) >= autoCompactThreshold
+	threshold := normalizeAutoCompactThreshold(i.cfg.AutoCompactThreshold)
+	return shouldAutoCompact(i.lastCtxInput, m.ContextWindow, threshold)
 }
 
 func (i *Interactive) handleEvent(ev core.AgentEvent) {

--- a/packages/agent/settings_store.go
+++ b/packages/agent/settings_store.go
@@ -50,6 +50,15 @@ func (configSettingsStore) SetAutoSwarm(enabled bool) error {
 	return SaveConfig(cfg)
 }
 
+func (configSettingsStore) SetAutoCompactThreshold(percent int) error {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+	cfg.AutoCompactThreshold = &percent
+	return SaveConfig(cfg)
+}
+
 func (configSettingsStore) SetJailByDefault(enabled bool) error {
 	cfg, err := LoadConfig()
 	if err != nil {

--- a/packages/agent/settings_store_test.go
+++ b/packages/agent/settings_store_test.go
@@ -43,3 +43,24 @@ func TestConfigSettingsStorePersistsJailByDefault(t *testing.T) {
 		t.Fatalf("unrelated config changed: theme = %q, want dark", cfg.Theme)
 	}
 }
+
+func TestConfigSettingsStorePersistsAutoCompactThreshold(t *testing.T) {
+	t.Setenv("ZOT_HOME", t.TempDir())
+	if err := SaveConfig(Config{Theme: "dark"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (configSettingsStore{}).SetAutoCompactThreshold(70); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AutoCompactThreshold == nil || *cfg.AutoCompactThreshold != 70 {
+		t.Fatalf("auto_compact_threshold = %v, want 70", cfg.AutoCompactThreshold)
+	}
+	if cfg.Theme != "dark" {
+		t.Fatalf("unrelated config changed: theme = %q, want dark", cfg.Theme)
+	}
+}


### PR DESCRIPTION
## Summary

- add an auto-compact threshold picker to `/settings` with `off`, `70%`, `80%`, `85%`, and `90%` presets
- persist the selection as `auto_compact_threshold` while preserving 85% as the default for missing or invalid values
- keep manual compaction and payload-too-large recovery active when percentage-based auto-compaction is off
- document the setting and add focused configuration, persistence, and threshold tests

## User impact

Interactive users can choose how much context headroom Zot keeps before condensing conversation history. Existing configurations retain the current 85% behavior without migration. RPC, SDK, bot, print, and JSON compaction behavior is unchanged.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`