### PR TITLE
feat(agent): add named subagent profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ logs/
 *.rej
 .tmp/
 tmp/
+.agent-reviews/
 npm/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Yet another coding agent harness, lightweight and written (vibe-slopped) in go.
 - user and extension themes via JSON; see [docs/themes.md](docs/themes.md).
 - standing instructions via `AGENTS.md` files (global and per-project); see [Persistent instructions](#persistent-instructions-agentsmd).
 - reusable instructions via `SKILL.md` files; see [docs/skills.md](docs/skills.md).
+- named subagent profiles from `~/.agents/agents/*.md`; see [docs/subagents.md](docs/subagents.md).
 - portable agents from local directories, `.zot` files, or temporary public GitHub downloads; see [docs/zotfiles.md](docs/zotfiles.md).
 
 ## Install
@@ -280,7 +281,7 @@ Slash command names are case-insensitive in the TUI and messaging backends; argu
 | `/session` | Four ops on the current session: `export` to a portable `.zotsession` file, `import` one back in, `fork` from a past user message into a new branch, `tree` to switch between branches. Opens a picker without an argument; direct forms: `/session export [path]`, `/session import <path>`, `/session fork`, `/session tree`. Default export destination is `~/Downloads`. |
 | `/jump` | Scroll the chat to a previous turn (or `/jump <text>` to filter). |
 | `/btw` | Side chat with full context that doesn't add to the main thread. |
-| `/swarm` | Spawn, monitor, and chat with background subagents. Each runs in parallel with your main session and shares its working directory. |
+| `/swarm` | Spawn, monitor, and chat with background subagents. Each runs in parallel with your main session and shares its working directory. Named profiles can be selected with `agent`; see [docs/subagents.md](docs/subagents.md). |
 | `/skills` | List discovered skills (SKILL.md files) and preview their bodies. |
 | `/compact` | Summarize the transcript into one message to free up context. |
 | `/study` | Run the canned prompt "Read and understand everything in the current directory." so the agent has full project context before you start asking targeted questions. Pass a path — typed, drag-dropped, or selected via `@` — to target a specific file or directory instead: `/study [dir:packages/]`, `/study cmd/zot/main.go`. |
@@ -341,7 +342,9 @@ Background subagents that run alongside your main session. Each one is a separat
 ```
 /swarm                            # open the dashboard
 /swarm new <task>                 # spawn an agent
+/swarm new --agent reviewer <task> # use a named markdown profile
 /swarm new --model gpt-5 <task>    # pin the new agent to a specific model
+/swarm new --reasoning high <task> # set the child reasoning level
 /swarm logs <id>                  # jump straight into one agent's transcript
 /swarm send <id> <text>           # send a follow-up without opening the dashboard
 /swarm resume                     # pick a stopped agent to bring back
@@ -376,14 +379,18 @@ Background subagents that run alongside your main session. Each one is a separat
 
 **`/session export` does NOT bundle subagents.** A `.zotsession` is just the main chat transcript; per-agent state (session file, unix-socket inbox) is machine-local and doesn't round-trip through a JSONL file. To share what an agent said, copy it out of the transcript view manually.
 
-**Auto-swarm.** With `/settings` -> auto-swarm on, the main agent gets a built-in `swarm_spawn` tool and a system-prompt nudge to use it. It can then fork sub-agents on its own when a request naturally splits into independent parallel work ("implement A and B", "investigate three files"). Each spawn returns the sub-agent id immediately and the main turn keeps going. When every sub-agent the agent spawned in that batch finishes its initial task, zot injects one `[auto-swarm update]` message back into the main chat recapping each agent's status, task, and complete final response. If an agent produced no assistant response, zot includes a truncated transcript tail for diagnostics instead. The main agent then writes a short follow-up summary referencing the agents by id. Off by default; toggle from `/settings`.
+**Auto-swarm.** With `/settings` -> auto-swarm on, the main agent gets a built-in `swarm_spawn` tool and a system-prompt nudge to use it. It can then fork sub-agents on its own when a request naturally splits into independent parallel work ("implement A and B", "investigate three files"). If named markdown profiles are available, zot adds a compact `[subagents_list]` to the main prompt; the model can choose a profile with the tool's `agent` field and optionally override its `model`, `provider`, or `reasoning`. Each spawn returns the sub-agent id immediately and the main turn keeps going. When every sub-agent the agent spawned in that batch finishes its initial task, zot injects one `[auto-swarm update]` message back into the main chat recapping each agent's status, task, and complete final response. If an agent produced no assistant response, zot includes a truncated transcript tail for diagnostics instead. The main agent then writes a short follow-up summary referencing the agents by id. Off by default; toggle from `/settings`.
+
+### Named subagent profiles
+
+zot discovers the common markdown/frontmatter profile layout from `~/.agents/agents/*.md` by default. With auto-swarm enabled, the main agent receives `[subagents_list]` metadata and can select a named profile through `swarm_spawn`. Profile bodies are applied only to the selected child. See [docs/subagents.md](docs/subagents.md) for discovery, supported fields, reasoning levels, and examples.
 
 ### `/settings`
 
 Opens a dialog with every persistent setting. `up`/`down` to navigate, `enter` or `space` to change the selected row, `esc` to close (rows that open a sub-view, like model shortcuts, use `esc` to go back one level first). Changes are written to `$ZOT_HOME/config.json` and take effect on the next turn (no restart needed). Current settings:
 
 - **render images when supported** — draw screenshots / `read`-returned images inline using the terminal's image protocol, or fall back to a text placeholder. Auto-detected from `TERM_PROGRAM`; the toggle overrides the detection. The row is greyed out and forced off on terminals that don't speak any image protocol.
-- **auto-swarm** — let the main agent spawn background sub-agents in parallel via a built-in `swarm_spawn` tool. Off by default. When on, the tool is registered with the running agent, the system prompt gains a short addendum telling the model to delegate independent sub-tasks proactively, and zot watches every sub-agent the main agent spawns. As soon as the last sub-agent in a batch finishes its initial task, an `[auto-swarm update]` message is injected back into the chat with each agent's status / task / transcript tail, so the main agent can summarise the collective outcome. Flipping off mid-session removes the tool from the live agent and strips the addendum on the next turn — the model stops trying to delegate. See `/swarm` for the dashboard that lets you monitor, message, kill, or remove the spawned agents.
+- **auto-swarm** — let the main agent spawn background sub-agents in parallel via a built-in `swarm_spawn` tool. Off by default. When on, the tool is registered with the running agent, the system prompt gains a short addendum telling the model to delegate independent sub-tasks proactively, and available named profiles are rendered in `[subagents_list]`. The tool accepts a profile name through `agent` and a per-child `reasoning`/`thinking` override. zot watches every sub-agent the main agent spawns. As soon as the last sub-agent in a batch finishes its initial task, an `[auto-swarm update]` message is injected back into the chat with each agent's status / task / transcript tail, so the main agent can summarise the collective outcome. Flipping off mid-session removes the tool from the live agent and strips the addendum on the next turn — the model stops trying to delegate. See `/swarm` and [docs/subagents.md](docs/subagents.md) for details.
 - **auto-compact threshold** — choose `off`, `70%`, `80%`, `85%` (default), or `90%` of the model's advertised context window. The selected percentage controls automatic compaction before and after interactive turns and persists as `auto_compact_threshold`. `off` disables percentage-based triggers but keeps manual `/compact` and automatic recovery from context-window and payload-too-large responses.
 - **jail new sessions by default**: start every new agent with tools confined to its working directory. Off by default. The setting applies to interactive, print, JSON, RPC, and background-agent runs, persists as `jail_by_default`, and immediately updates the current interactive session. `/jail` and `/unjail` remain session-scoped overrides and do not change this default.
 - **compact transcript rendering**: reduce visual chrome in the chat transcript. Tool calls render as a quiet header plus indented output instead of a bordered box, and sent messages render without padded background bubbles. Off by default. Changes apply immediately and persist to `config.json` as `compact_mode`.
@@ -1026,6 +1033,7 @@ packages/agent/modes/bot/             protocol-agnostic bot runner (BotAdapter i
 packages/agent/modes/telegram/        telegram adapter, api client, daemon
 packages/agent/tools/                 read, write, edit, bash, sandbox
 packages/agent/skills/                skill discovery, frontmatter parser, skill tool
+packages/agent/subagents/             named markdown profile discovery and dispatch
 packages/agent/swarm/                 background subagent runtime
 packages/agent/sdk/                   public Go SDK for embedding zot in-process (package sdk)
 packages/agent/ext/                   public Go SDK for writing extensions (package ext)

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -1,0 +1,85 @@
+# Named subagent profiles
+
+zot can discover reusable named subagent definitions from markdown files with a frontmatter block. This is a common agent-profile layout and is not tied to a particular host application.
+
+## Discovery
+
+The default directory is:
+
+```text
+~/.agents/agents/*.md
+```
+
+zot also reads these optional locations:
+
+- directories listed in `ZOT_AGENT_PROFILES` (use the platform path-list separator)
+- `~/.pi/agent/agents/*.md` as a compatibility fallback
+
+Profiles are read-only inputs. zot does not execute files from these directories. Project-local profile directories are not scanned automatically; use `ZOT_AGENT_PROFILES` when a project intentionally opts into an additional profile directory.
+
+## File format
+
+```markdown
+---
+name: reviewer
+description: Read-only code reviewer
+tools: read, grep, find, ls, diagnostics, code_search
+model: openai-codex/gpt-5.6-luna
+thinking: max
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+---
+
+You are a review worker. Inspect the requested scope, report evidence-backed findings, and do not edit files.
+```
+
+Supported metadata:
+
+| Field | Meaning |
+|---|---|
+| `name` | Name passed to `swarm_spawn`'s `agent` field. Falls back to the filename. |
+| `description` | Short description shown to the main agent. |
+| `tools` | Comma-separated or list-form tool names. zot currently enforces its own `read`, `write`, `edit`, and `bash` registry; unknown names do not grant capabilities. |
+| `model` | Optional model ID. A qualified value such as `openai-codex/gpt-5.6-luna` selects both provider and model. |
+| `provider` | Optional separate provider ID for a model without a provider prefix. |
+| `thinking` / `reasoning` | Optional reasoning level: `off`, `minimum`, `low`, `medium`, `high`, `xhigh`, or `max`. |
+| `systemPromptMode` | `append` (default) or `replace`. |
+| `inheritProjectContext` | Set to `false` to omit `AGENTS.md` context from the child. |
+| `inheritSkills` | Set to `false` to omit skill discovery from the child. |
+
+Other frontmatter from another agent host is ignored when zot does not have an equivalent setting. For example, `maxSubagentDepth` is currently not enforced by zot.
+
+## Selecting a profile
+
+When **auto-swarm** is enabled in `/settings`, the main agent receives a compact `[subagents_list]` section in its system prompt and can select a profile:
+
+```json
+{
+  "task": "Review the authentication package and report correctness or security issues.",
+  "agent": "reviewer"
+}
+```
+
+The selected profile's body, model, thinking level, system-prompt mode, context inheritance, and tool selection are applied to the child. The parent prompt contains only profile metadata; the full body is loaded by the child after explicit selection.
+
+A per-spawn reasoning override is also accepted:
+
+```json
+{
+  "task": "Implement the parser change and add regression tests.",
+  "agent": "implementer",
+  "reasoning": "high"
+}
+```
+
+`thinking` is accepted as an alias for `reasoning`. If neither is supplied, the child inherits the host reasoning level for an unnamed spawn, or the profile's `thinking` value for a named spawn.
+
+The interactive command also supports the same selection explicitly:
+
+```text
+/swarm new --agent reviewer Review the authentication package
+/swarm new --agent implementer --reasoning high Implement the parser change
+```
+
+All swarm children still share the host working directory. Named profiles change the child's instructions and configuration; they do not create a worktree, branch, or security sandbox.

--- a/packages/agent/args.go
+++ b/packages/agent/args.go
@@ -119,6 +119,12 @@ type Args struct {
 	// --swarm-agent <path>; presence flips Mode to ModeSwarmAgent.
 	SwarmAgent string
 
+	// Subagent selects a named markdown profile for a swarm child.
+	// It is intentionally an internal child flag; the parent swarm tool
+	// passes only the profile name and the child discovers the definition
+	// locally.
+	Subagent string
+
 	// AgentName/AgentDataDir/PermissionSet are populated by `zot run`
 	// for local zotfile agents. They scope sessions and enforce the
 	// manifest's declared file/bash permissions.
@@ -273,6 +279,12 @@ func ParseArgs(in []string) (Args, error) {
 			}
 			a.SwarmAgent = v
 			a.Mode = ModeSwarmAgent
+		case "--subagent":
+			v, err := want(&i, arg)
+			if err != nil {
+				return a, err
+			}
+			a.Subagent = v
 		case "--tools":
 			v, err := want(&i, arg)
 			if err != nil {

--- a/packages/agent/args_test.go
+++ b/packages/agent/args_test.go
@@ -2,6 +2,16 @@ package agent
 
 import "testing"
 
+func TestParseArgsSubagentAndReasoning(t *testing.T) {
+	args, err := ParseArgs([]string{"--swarm-agent", "/tmp/in.sock", "--subagent", "reviewer", "--reasoning", "high", "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if args.Mode != ModeSwarmAgent || args.Subagent != "reviewer" || args.Reasoning != "high" || args.Prompt != "task" {
+		t.Fatalf("parsed args = mode=%q subagent=%q reasoning=%q prompt=%q", args.Mode, args.Subagent, args.Reasoning, args.Prompt)
+	}
+}
+
 func TestParseArgsTemperatureAllowsZero(t *testing.T) {
 	args, err := ParseArgs([]string{"--temperature", "0"})
 	if err != nil {

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -10,6 +10,7 @@ import (
 
 	zotdocs "github.com/patriceckhart/zot"
 	"github.com/patriceckhart/zot/packages/agent/skills"
+	"github.com/patriceckhart/zot/packages/agent/subagents"
 	"github.com/patriceckhart/zot/packages/agent/tools"
 	"github.com/patriceckhart/zot/packages/core"
 	"github.com/patriceckhart/zot/packages/provider"
@@ -302,6 +303,44 @@ func canonicalProvider(name string) string {
 	return n
 }
 
+func findSubagentProfile(cwd, name string) (*subagents.Profile, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, nil
+	}
+	home, _ := os.UserHomeDir()
+	profiles, _ := subagents.Discover(cwd, home)
+	profile := subagents.Find(profiles, name)
+	if profile == nil {
+		return nil, fmt.Errorf("subagent profile %q not found (looked in ~/.agents/agents and compatibility locations)", name)
+	}
+	return profile, nil
+}
+
+func applySubagentProfile(args *Args, profile *subagents.Profile) {
+	if args == nil || profile == nil {
+		return
+	}
+	profileProvider, profileModel := profile.ModelSelection()
+	if args.Provider == "" && profileProvider != "" {
+		args.Provider = profileProvider
+	}
+	if args.Model == "" && profileModel != "" {
+		args.Model = profileModel
+	}
+	if args.Reasoning == "" && profile.Thinking != "" {
+		// Keep an explicit "off" value non-empty so it overrides a
+		// persisted global reasoning setting when the child resolves.
+		args.Reasoning = strings.TrimSpace(profile.Thinking)
+	}
+	if !args.NoTools && len(args.Tools) == 0 && len(profile.Tools) > 0 {
+		args.Tools = append([]string(nil), profile.Tools...)
+	}
+	if profile.InheritSkills != nil && !*profile.InheritSkills {
+		args.NoSkill = true
+	}
+}
+
 // Resolve merges args, config, and env into a Resolved set.
 //
 // Unlike the earlier version, Resolve NEVER returns an error for
@@ -310,6 +349,15 @@ func canonicalProvider(name string) string {
 // hard error (used by print/json modes).
 func Resolve(args Args, requireCred bool) (Resolved, error) {
 	cfg, _ := LoadConfig()
+	var selectedProfile *subagents.Profile
+	if strings.TrimSpace(args.Subagent) != "" {
+		var err error
+		selectedProfile, err = findSubagentProfile(args.CWD, args.Subagent)
+		if err != nil {
+			return Resolved{}, err
+		}
+		applySubagentProfile(&args, selectedProfile)
+	}
 
 	// User-requested provider (explicit > config > default).
 	// Normalise common aliases (e.g. "bedrock" -> "amazon-bedrock")
@@ -586,7 +634,7 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 		skillTool     *skills.Tool
 		skillAddendum string
 	)
-	if !args.NoSkill {
+	if !args.NoSkill && (selectedProfile == nil || selectedProfile.InheritSkills == nil || *selectedProfile.InheritSkills) {
 		homeDir, _ := os.UserHomeDir()
 		discovered, _ = skills.Discover(ZotHome(), args.CWD, homeDir, args.WithSkills)
 		if len(discovered) > 0 {
@@ -599,7 +647,10 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 
 	summaries := toolSummaries(reg, args)
 
-	contextFiles := loadAgentsContext(args.CWD, ZotHome())
+	contextFiles := []ContextFile(nil)
+	if selectedProfile == nil || selectedProfile.InheritProjectContext == nil || *selectedProfile.InheritProjectContext {
+		contextFiles = loadAgentsContext(args.CWD, ZotHome())
+	}
 	append_ := append([]string(nil), args.AppendSystemPrompt...)
 	if agentsAddendum := formatAgentsContext(contextFiles); agentsAddendum != "" {
 		append_ = append(append_, agentsAddendum)
@@ -607,8 +658,17 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 	if skillAddendum != "" {
 		append_ = append(append_, skillAddendum)
 	}
-	if AutoSwarmEnabled() {
+	interactiveMode := args.Mode == "" || args.Mode == ModeInteractive
+	if selectedProfile == nil && interactiveMode && cfg.AutoSwarmEnabled != nil && *cfg.AutoSwarmEnabled {
+		homeDir, _ := os.UserHomeDir()
+		profiles, _ := subagents.Discover(args.CWD, homeDir)
+		if subagentsAddendum := subagents.SystemPromptAddendum(profiles); subagentsAddendum != "" {
+			append_ = append(append_, subagentsAddendum)
+		}
 		append_ = append(append_, AutoSwarmSystemAddendum)
+	}
+	if selectedProfile != nil && selectedProfile.SystemPromptMode != "replace" && selectedProfile.SystemPrompt != "" {
+		append_ = append(append_, selectedProfile.SystemPrompt)
 	}
 
 	// Custom system prompt resolution order:
@@ -616,7 +676,9 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 	//   2. $ZOT_HOME/SYSTEM.md (persistent user override)
 	//   3. built-in default (defaultIdentity + defaultGuidelines)
 	custom := args.SystemPrompt
-	if custom == "" {
+	if selectedProfile != nil && selectedProfile.SystemPromptMode == "replace" {
+		custom = selectedProfile.SystemPrompt
+	} else if custom == "" {
 		custom = readUserSystemPrompt(ZotHome())
 	}
 

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -309,7 +309,10 @@ func findSubagentProfile(cwd, name string) (*subagents.Profile, error) {
 		return nil, nil
 	}
 	home, _ := os.UserHomeDir()
-	profiles, _ := subagents.Discover(cwd, home)
+	profiles, discoveryErrors := subagents.Discover(cwd, home)
+	if len(discoveryErrors) > 0 {
+		return nil, fmt.Errorf("discover subagent profiles: %d profile discovery error(s)", len(discoveryErrors))
+	}
 	profile := subagents.Find(profiles, name)
 	if profile == nil {
 		return nil, fmt.Errorf("subagent profile %q not found (looked in ~/.agents/agents and compatibility locations)", name)

--- a/packages/agent/build_test.go
+++ b/packages/agent/build_test.go
@@ -59,6 +59,25 @@ func TestReadAgentsContextLoadsGlobalAndAncestors(t *testing.T) {
 	}
 }
 
+func TestFindSubagentProfileReportsDiscoveryFailure(t *testing.T) {
+	profileSource := filepath.Join(t.TempDir(), "profiles.md")
+	if err := os.WriteFile(profileSource, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ZOT_AGENT_PROFILES", profileSource)
+
+	profile, err := findSubagentProfile("", "reviewer")
+	if profile != nil {
+		t.Fatalf("profile = %#v, want nil", profile)
+	}
+	if err == nil || !strings.Contains(err.Error(), "discover subagent profiles") {
+		t.Fatalf("error = %v, want discovery failure", err)
+	}
+	if strings.Contains(err.Error(), profileSource) {
+		t.Fatalf("error leaked profile path: %v", err)
+	}
+}
+
 func TestResolveIncludesNamedSubagentsListWhenAutoSwarmIsEnabled(t *testing.T) {
 	root := t.TempDir()
 	home := filepath.Join(root, "home")

--- a/packages/agent/build_test.go
+++ b/packages/agent/build_test.go
@@ -91,6 +91,7 @@ func TestResolveIncludesNamedSubagentsListWhenAutoSwarmIsEnabled(t *testing.T) {
 	}
 	t.Setenv("HOME", home)
 	t.Setenv("ZOT_HOME", zotHome)
+	t.Setenv("ZOT_AGENT_PROFILES", filepath.Join(home, ".agents", "agents"))
 	enabled := true
 	if err := SaveConfig(Config{Provider: "openai", Model: "gpt-5", AutoSwarmEnabled: &enabled}); err != nil {
 		t.Fatal(err)
@@ -130,6 +131,7 @@ func TestResolveAppliesSelectedSubagentProfile(t *testing.T) {
 	}
 	t.Setenv("HOME", home)
 	t.Setenv("ZOT_HOME", zotHome)
+	t.Setenv("ZOT_AGENT_PROFILES", filepath.Join(home, ".agents", "agents"))
 	if err := SaveConfig(Config{Provider: "openai", Model: "gpt-5", Reasoning: "high"}); err != nil {
 		t.Fatal(err)
 	}

--- a/packages/agent/build_test.go
+++ b/packages/agent/build_test.go
@@ -59,6 +59,97 @@ func TestReadAgentsContextLoadsGlobalAndAncestors(t *testing.T) {
 	}
 }
 
+func TestResolveIncludesNamedSubagentsListWhenAutoSwarmIsEnabled(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	zotHome := filepath.Join(root, "zot-home")
+	project := filepath.Join(root, "repo")
+	if err := os.MkdirAll(filepath.Join(home, ".agents", "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("ZOT_HOME", zotHome)
+	enabled := true
+	if err := SaveConfig(Config{Provider: "openai", Model: "gpt-5", AutoSwarmEnabled: &enabled}); err != nil {
+		t.Fatal(err)
+	}
+	profile := `---
+name: reviewer
+description: Read-only code reviewer
+thinking: high
+---
+Review without editing.
+`
+	if err := os.WriteFile(filepath.Join(home, ".agents", "agents", "reviewer.md"), []byte(profile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Resolve(Args{CWD: project}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"[subagents_list]", "reviewer", "Read-only code reviewer", "[/subagents_list]"} {
+		if !strings.Contains(r.SystemPrompt, want) {
+			t.Fatalf("system prompt missing %q:\n%s", want, r.SystemPrompt)
+		}
+	}
+}
+
+func TestResolveAppliesSelectedSubagentProfile(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	zotHome := filepath.Join(root, "zot-home")
+	project := filepath.Join(root, "repo")
+	if err := os.MkdirAll(filepath.Join(home, ".agents", "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("ZOT_HOME", zotHome)
+	if err := SaveConfig(Config{Provider: "openai", Model: "gpt-5", Reasoning: "high"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(zotHome, "AGENTS.md"), []byte("global context"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profile := `---
+name: reviewer
+description: Read-only code reviewer
+tools: read
+thinking: off
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+---
+You are a read-only reviewer.
+`
+	if err := os.WriteFile(filepath.Join(home, ".agents", "agents", "reviewer.md"), []byte(profile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Resolve(Args{CWD: project, Subagent: "reviewer"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Reasoning != "" {
+		t.Fatalf("profile thinking=off did not override config reasoning: %q", r.Reasoning)
+	}
+	if _, ok := r.ToolRegistry["read"]; !ok || len(r.ToolRegistry) != 1 {
+		t.Fatalf("profile tools = %#v, want only read", r.ToolRegistry)
+	}
+	if len(r.ContextFiles) != 0 {
+		t.Fatalf("profile inheritProjectContext=false loaded %#v", r.ContextFiles)
+	}
+	if !strings.Contains(r.SystemPrompt, "You are a read-only reviewer.") || strings.Contains(r.SystemPrompt, "global context") {
+		t.Fatalf("profile system prompt inheritance is wrong:\n%s", r.SystemPrompt)
+	}
+}
+
 func TestReadAgentsContextMissingFilesIsEmpty(t *testing.T) {
 	files := loadAgentsContext(t.TempDir(), t.TempDir())
 	if len(files) != 0 {

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -19,6 +19,7 @@ import (
 	"github.com/patriceckhart/zot/packages/agent/extproto"
 	"github.com/patriceckhart/zot/packages/agent/modes"
 	"github.com/patriceckhart/zot/packages/agent/skills"
+	"github.com/patriceckhart/zot/packages/agent/subagents"
 	"github.com/patriceckhart/zot/packages/agent/swarm"
 	"github.com/patriceckhart/zot/packages/agent/tools"
 	"github.com/patriceckhart/zot/packages/core"
@@ -729,6 +730,9 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			iv.TrackSwarmAgent(a, task)
 		}
 	}
+	resolveSubagent := func(name string) (*subagents.Profile, error) {
+		return findSubagentProfile(r.CWD, name)
+	}
 
 	// Inject the swarm_spawn auto-swarm tool only when /settings ->
 	// auto-swarm is currently enabled. Registering it unconditionally
@@ -744,11 +748,13 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			return reg
 		}
 		reg["swarm_spawn"] = &tools.SwarmSpawnTool{
-			Swarm:           swarmMgr,
-			Enabled:         AutoSwarmEnabled,
-			DefaultModel:    func() string { return r.Model },
-			DefaultProvider: func() string { return r.Provider },
-			OnSpawned:       onSpawnedSwarm,
+			Swarm:            swarmMgr,
+			Enabled:          AutoSwarmEnabled,
+			DefaultModel:     func() string { return r.Model },
+			DefaultProvider:  func() string { return r.Provider },
+			DefaultReasoning: func() string { return r.Reasoning },
+			ResolveSubagent:  resolveSubagent,
+			OnSpawned:        onSpawnedSwarm,
 		}
 		return reg
 	}
@@ -1247,6 +1253,9 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 	if r.SkillTool != nil {
 		startupSkills = r.SkillTool.Skills()
 	}
+	homeDir, _ := os.UserHomeDir()
+	discoveredSubagents, _ := subagents.Discover(r.CWD, homeDir)
+	subagentsAddendum := subagents.SystemPromptAddendum(discoveredSubagents)
 
 	iv = modes.NewInteractive(modes.InteractiveConfig{
 		Terminal:                  term,
@@ -1267,6 +1276,7 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		CompactUser:               initialCfg.CompactUserInput(),
 		ExtensionThemes:           extMgr.ThemeOptions,
 		AutoSwarmSystemAddendum:   AutoSwarmSystemAddendum,
+		SubagentsSystemAddendum:   subagentsAddendum,
 		SettingsStore:             configSettingsStore{},
 		Model:                     r.Model,
 		Provider:                  r.Provider,
@@ -1360,9 +1370,10 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			writeNewTranscriptLocked(currentAg, sess, sessBaselineMsgs)
 			sessBaselineMsgs = len(currentAg.Messages())
 		},
-		Extensions:    extMgr,
-		Swarm:         swarmMgr,
-		ChangelogChan: changelogCh,
+		Extensions:      extMgr,
+		Swarm:           swarmMgr,
+		ResolveSubagent: resolveSubagent,
+		ChangelogChan:   changelogCh,
 		OnChangelogDismiss: func() {
 			// For dev builds (0.0.0) store the actual release version
 			// so the same changelog doesn't show again next launch.

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -1054,17 +1054,10 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 	//
 	// Steps, in order:
 	//   1. resolve + validate the new path (~ expansion, abs/rel)
-	//   2. close the current session, flushing pending messages
-	//   3. mutate captured args.CWD + r.CWD so future buildAgent
-	//      calls bind to the new cwd
-	//   4. re-root the shared sandbox («·«) so /jail follows the
-	//      session into the new cwd instead of widening or silently
-	//      dropping
-	//   5. rebuild the agent via buildAgent() so tools, AGENTS.md
-	//      addendum, system prompt, sessions dir all bind correctly
-	//   6. open a fresh session in the new cwd's bucket
-	//   7. push the new state into the running Interactive
-	//   8. re-scope the swarm dashboard to the freshly-opened session
+	//   2. stage the candidate cwd, sandbox, and swarm state
+	//   3. rebuild the agent and allocate its new session
+	//   4. commit all new state together, closing the old session last
+	//   5. push the committed state into the running Interactive
 	//
 	// The /jail state is preserved verbatim: if the sandbox was locked
 	// to the old cwd, it stays locked, just re-pointed at the new one.
@@ -1104,21 +1097,39 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			return fmt.Errorf("no agent running; log in first")
 		}
 
-		// Close the current session before we drop the reference.
-		// Per-message persistence keeps it current already; this is
-		// a defensive flush + final fsync via Close.
-		persistMu.Lock()
-		if sess != nil {
-			writeNewTranscriptLocked(currentAg, sess, sessBaselineMsgs)
-			_ = sess.Close()
-			sess = nil
+		// Stage the candidate state while retaining a complete rollback
+		// snapshot. A failed rebuild or session allocation must leave the
+		// current agent, session, sandbox, and swarm root usable.
+		oldCWD := args.CWD
+		oldResolvedCWD := r.CWD
+		oldPermissionSet := args.PermissionSet
+		oldSwarmRoot := ""
+		if swarmMgr != nil {
+			oldSwarmRoot = swarmMgr.RepoRoot()
 		}
-		sessBaselineMsgs = 0
-		persistMu.Unlock()
+		oldSandboxRoot := ""
+		oldSandboxLocked := false
+		if sharedSandbox != nil {
+			oldSandboxRoot = sharedSandbox.Root
+			oldSandboxLocked = sharedSandbox.Locked()
+		}
+		rollback := func() {
+			args.CWD = oldCWD
+			r.CWD = oldResolvedCWD
+			args.PermissionSet = oldPermissionSet
+			if swarmMgr != nil {
+				swarmMgr.SetRepoRoot(oldSwarmRoot)
+			}
+			if sharedSandbox != nil {
+				sharedSandbox.Root = oldSandboxRoot
+				if oldSandboxLocked {
+					sharedSandbox.Lock()
+				} else {
+					sharedSandbox.Unlock()
+				}
+			}
+		}
 
-		// Mutate captured state so subsequent agent rebuilds and
-		// session opens see the new cwd.
-		wasJailed := sharedSandbox != nil && sharedSandbox.Locked()
 		args.CWD = absPath
 		r.CWD = absPath
 		if swarmMgr != nil {
@@ -1130,7 +1141,7 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		}
 		if sharedSandbox != nil {
 			sharedSandbox.Root = absPath
-			if wasJailed {
+			if oldSandboxLocked {
 				sharedSandbox.Lock()
 			} else {
 				sharedSandbox.Unlock()
@@ -1141,26 +1152,37 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		// re-bind to the new cwd. buildAgent() reads from args + r.
 		newAg, newProvider, newModel, berr := buildAgent()
 		if berr != nil {
+			rollback()
 			return fmt.Errorf("rebuild agent: %v", berr)
 		}
-		ag = newAg
 
 		// Fresh session in the new cwd's bucket. We bypass
 		// openOrCreateSession's --continue / --resume branches
 		// because /cd's semantics are "start fresh here", matching
 		// what relaunching `zot --cwd <path>` would do today.
+		var newSess *core.Session
 		if !args.NoSess {
 			newRoot := agentSessionsRoot(ZotHome(), args)
 			core.PruneEmptySessions(newRoot, absPath)
-			newSess, serr := core.NewSession(newRoot, absPath, newProvider, newModel, version)
+			var serr error
+			newSess, serr = core.NewSession(newRoot, absPath, newProvider, newModel, version)
 			if serr != nil {
+				rollback()
 				return fmt.Errorf("open session in %s: %v", absPath, serr)
 			}
-			persistMu.Lock()
-			sess = newSess
-			sessBaselineMsgs = 0
-			persistMu.Unlock()
 		}
+
+		// Commit only after every fallible operation has succeeded. Close
+		// the old session last so rollback never has to resurrect it.
+		persistMu.Lock()
+		if sess != nil {
+			writeNewTranscriptLocked(currentAg, sess, sessBaselineMsgs)
+			_ = sess.Close()
+		}
+		sess = newSess
+		sessBaselineMsgs = 0
+		persistMu.Unlock()
+		ag = newAg
 
 		// Push the new state into the running Interactive.
 		if iv != nil {
@@ -1169,8 +1191,8 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		}
 
 		// Re-scope the swarm dashboard to the new session.
-		if swarmMgr != nil && sess != nil {
-			swarmMgr.SetActiveSession(sess.ID)
+		if swarmMgr != nil && newSess != nil {
+			swarmMgr.SetActiveSession(newSess.ID)
 		}
 		return nil
 	}

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -1121,6 +1121,9 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		wasJailed := sharedSandbox != nil && sharedSandbox.Locked()
 		args.CWD = absPath
 		r.CWD = absPath
+		if swarmMgr != nil {
+			swarmMgr.SetRepoRoot(absPath)
+		}
 		if args.PermissionSet != nil {
 			expanded := args.PermissionSet.Expand(absPath, args.AgentDataDir)
 			args.PermissionSet = &expanded

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -1153,7 +1153,7 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		newAg, newProvider, newModel, berr := buildAgent()
 		if berr != nil {
 			rollback()
-			return fmt.Errorf("rebuild agent: %v", berr)
+			return fmt.Errorf("rebuild agent: %w", berr)
 		}
 
 		// Fresh session in the new cwd's bucket. We bypass
@@ -1168,7 +1168,7 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			newSess, serr = core.NewSession(newRoot, absPath, newProvider, newModel, version)
 			if serr != nil {
 				rollback()
-				return fmt.Errorf("open session in %s: %v", absPath, serr)
+				return fmt.Errorf("open session in %s: %w", absPath, serr)
 			}
 		}
 

--- a/packages/agent/modes/auto_swarm_test.go
+++ b/packages/agent/modes/auto_swarm_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/patriceckhart/zot/packages/core"
 )
 
+func TestAutoSwarmSystemPromptTogglesProfileManifestWithDelegationGuidance(t *testing.T) {
+	iv := &Interactive{
+		agent: &core.Agent{System: "base system"},
+		cfg: InteractiveConfig{
+			AutoSwarmSystemAddendum: "auto-swarm guidance",
+			SubagentsSystemAddendum: "[subagents_list]\n- reviewer\n[/subagents_list]",
+		},
+	}
+
+	iv.applyAutoSwarmSystemPrompt(true)
+	if !strings.Contains(iv.agent.System, "[subagents_list]") || !strings.Contains(iv.agent.System, "auto-swarm guidance") {
+		t.Fatalf("enabled system prompt missing swarm blocks: %q", iv.agent.System)
+	}
+	before := iv.agent.System
+	iv.applyAutoSwarmSystemPrompt(true)
+	if iv.agent.System != before {
+		t.Fatalf("enabling twice changed system prompt: %q -> %q", before, iv.agent.System)
+	}
+
+	iv.applyAutoSwarmSystemPrompt(false)
+	if strings.Contains(iv.agent.System, "[subagents_list]") || strings.Contains(iv.agent.System, "auto-swarm guidance") {
+		t.Fatalf("disabled system prompt retained swarm blocks: %q", iv.agent.System)
+	}
+}
+
 func TestAutoSwarmSummaryIncludesCompleteFinalResponseAfterLongTask(t *testing.T) {
 	response := "first response line\n" + strings.Repeat("result ", 150) + "final marker"
 	mgr := swarm.New(swarm.Config{

--- a/packages/agent/modes/auto_swarm_test.go
+++ b/packages/agent/modes/auto_swarm_test.go
@@ -36,6 +36,28 @@ func TestAutoSwarmSystemPromptTogglesProfileManifestWithDelegationGuidance(t *te
 	}
 }
 
+func TestAutoSwarmTogglePreservesMatchingBasePromptBlocks(t *testing.T) {
+	manifest := "[subagents_list]\n- reviewer\n[/subagents_list]"
+	guidance := "auto-swarm guidance"
+	base := "base system\n\n" + manifest + "\n\n" + guidance
+	iv := &Interactive{
+		agent: &core.Agent{System: base},
+		cfg: InteractiveConfig{
+			AutoSwarmSystemAddendum: guidance,
+			SubagentsSystemAddendum: manifest,
+		},
+	}
+
+	iv.applyAutoSwarmSystemPrompt(true)
+	if strings.Count(iv.agent.System, manifest) != 2 || strings.Count(iv.agent.System, guidance) != 2 {
+		t.Fatalf("enabling should append owned duplicate blocks: %q", iv.agent.System)
+	}
+	iv.applyAutoSwarmSystemPrompt(false)
+	if got := strings.TrimSpace(iv.agent.System); got != base {
+		t.Fatalf("disabling changed matching base prompt: %q; want %q", got, base)
+	}
+}
+
 func TestAutoSwarmSummaryIncludesCompleteFinalResponseAfterLongTask(t *testing.T) {
 	response := "first response line\n" + strings.Repeat("result ", 150) + "final marker"
 	mgr := swarm.New(swarm.Config{

--- a/packages/agent/modes/interactive.go
+++ b/packages/agent/modes/interactive.go
@@ -16,6 +16,7 @@ import (
 	"github.com/patriceckhart/zot/packages/agent/extproto"
 	"github.com/patriceckhart/zot/packages/agent/modes/telegram"
 	"github.com/patriceckhart/zot/packages/agent/skills"
+	"github.com/patriceckhart/zot/packages/agent/subagents"
 	"github.com/patriceckhart/zot/packages/agent/swarm"
 	"github.com/patriceckhart/zot/packages/agent/tools"
 	"github.com/patriceckhart/zot/packages/core"
@@ -123,6 +124,10 @@ type InteractiveConfig struct {
 	// Plumbed in from the cli so this package doesn't have to import
 	// agent (cycle).
 	AutoSwarmSystemAddendum string
+
+	// SubagentsSystemAddendum is the metadata-only [subagents_list]
+	// block that is added or removed together with auto-swarm.
+	SubagentsSystemAddendum string
 	SettingsStore           SettingsStore
 
 	// Agent is optional. If nil, zot opens without credentials; the
@@ -261,6 +266,11 @@ type InteractiveConfig struct {
 	// feature entirely (used by embedders / tests that don't want
 	// subprocesses).
 	Swarm *swarm.Swarm
+
+	// ResolveSubagent validates a named markdown profile for direct
+	// /swarm commands. Auto-swarm uses the equivalent callback on its
+	// tool; keeping this optional preserves lightweight embedders.
+	ResolveSubagent func(name string) (*subagents.Profile, error)
 
 	// SkillSnapshot, if non-nil, returns the current list of
 	// discovered SKILL.md files. Re-invoked each time /skills opens
@@ -3052,9 +3062,14 @@ func (i *Interactive) ApplyChangedCWDWithStartupContext(ag *core.Agent, provider
 }
 
 func (i *Interactive) applyChangedCWD(ag *core.Agent, provider, model, cwd string, startupContextPaths []string) {
+	home, _ := os.UserHomeDir()
+	profiles, _ := subagents.Discover(cwd, home)
+	subagentsAddendum := subagents.SystemPromptAddendum(profiles)
+
 	i.mu.Lock()
 	i.agent = ag
 	i.cfg.CWD = cwd
+	i.cfg.SubagentsSystemAddendum = subagentsAddendum
 	i.cfg.StartupContextPaths = append([]string(nil), startupContextPaths...)
 	i.view.StartupContextPaths = nil
 	if i.cfg.ShowInstructionsAtStartup != nil && *i.cfg.ShowInstructionsAtStartup {
@@ -6487,28 +6502,48 @@ func truncateForSummary(s string, n int) string {
 }
 
 // applyAutoSwarmSystemPrompt appends (active=true) or strips
-// (active=false) the auto-swarm system-prompt block on the running
-// agent so the model proactively considers swarm_spawn when the user
-// flips the toggle. The block lives at the tail of agent.System so
-// stripping is a plain suffix-trim; idempotent in both directions.
+// (active=false) the auto-swarm prompt blocks on the running agent.
+// The profile manifest and delegation guidance are managed together so
+// toggling auto-swarm never leaves the model with names but no tool.
 func (i *Interactive) applyAutoSwarmSystemPrompt(active bool) {
 	if i.agent == nil {
 		return
 	}
-	addendum := i.cfg.AutoSwarmSystemAddendum
-	if addendum == "" {
+	addenda := make([]string, 0, 2)
+	if addendum := strings.TrimSpace(i.cfg.SubagentsSystemAddendum); addendum != "" {
+		addenda = append(addenda, addendum)
+	}
+	if addendum := strings.TrimSpace(i.cfg.AutoSwarmSystemAddendum); addendum != "" {
+		addenda = append(addenda, addendum)
+	}
+	if len(addenda) == 0 {
 		return
 	}
+
 	sys := i.agent.System
-	has := strings.Contains(sys, addendum)
-	switch {
-	case active && !has:
-		if sys != "" && !strings.HasSuffix(sys, "\n\n") {
-			sys += "\n\n"
+	if active {
+		for _, addendum := range addenda {
+			if strings.Contains(sys, addendum) {
+				continue
+			}
+			if sys != "" && !strings.HasSuffix(sys, "\n\n") {
+				sys += "\n\n"
+			}
+			sys += addendum
 		}
-		i.agent.System = sys + addendum
-	case !active && has:
-		i.agent.System = strings.TrimRight(strings.ReplaceAll(sys, addendum, ""), "\n") + "\n"
+		i.agent.System = sys
+		return
+	}
+
+	changed := false
+	for _, addendum := range addenda {
+		if strings.Contains(sys, addendum) {
+			changed = true
+			sys = strings.ReplaceAll(sys, addendum, "")
+		}
+	}
+	if changed {
+		i.agent.System = strings.TrimRight(sys, "\n") + "\n"
 	}
 }
 
@@ -6535,11 +6570,13 @@ func (i *Interactive) applyAutoSwarmTool(active bool) {
 	}
 	if active && i.cfg.Swarm != nil {
 		next["swarm_spawn"] = &tools.SwarmSpawnTool{
-			Swarm:           i.cfg.Swarm,
-			Enabled:         func() bool { return true },
-			DefaultModel:    func() string { return i.cfg.Model },
-			DefaultProvider: func() string { return i.cfg.Provider },
-			OnSpawned:       i.trackSwarmAgent,
+			Swarm:            i.cfg.Swarm,
+			Enabled:          func() bool { return true },
+			DefaultModel:     func() string { return i.cfg.Model },
+			DefaultProvider:  func() string { return i.cfg.Provider },
+			DefaultReasoning: func() string { return i.cfg.Reasoning },
+			ResolveSubagent:  i.cfg.ResolveSubagent,
+			OnSpawned:        i.trackSwarmAgent,
 		}
 	}
 	i.agent.SetTools(next)

--- a/packages/agent/modes/interactive.go
+++ b/packages/agent/modes/interactive.go
@@ -368,10 +368,14 @@ type Interactive struct {
 	ed   *tui.Editor
 	rend *tui.Renderer
 
-	mu        sync.Mutex
-	agent     *core.Agent
-	streaming strings.Builder // what's currently painted on screen
-	streamOn  bool
+	mu    sync.Mutex
+	agent *core.Agent
+	// managedAutoSwarmAddenda records exact prompt blocks appended by
+	// auto-swarm. Disable only removes these owned occurrences, leaving
+	// identical text that came from the user's base prompt untouched.
+	managedAutoSwarmAddenda []string
+	streaming               strings.Builder // what's currently painted on screen
+	streamOn                bool
 
 	// streamPending is the runes buffered after each EvTextDelta that
 	// haven't yet been promoted into `streaming` for rendering. It
@@ -665,6 +669,9 @@ func NewInteractive(cfg InteractiveConfig) *Interactive {
 	if cfg.LlamaCPPConfig != nil {
 		baseURL, _, err := cfg.LlamaCPPConfig()
 		i.llamaConfigured = err == nil && baseURL != ""
+	}
+	if cfg.AutoSwarmEnabled != nil && *cfg.AutoSwarmEnabled {
+		i.managedAutoSwarmAddenda = autoSwarmAddenda(cfg)
 	}
 	if cfg.Agent != nil {
 		i.agent = cfg.Agent
@@ -3070,6 +3077,11 @@ func (i *Interactive) applyChangedCWD(ag *core.Agent, provider, model, cwd strin
 	i.agent = ag
 	i.cfg.CWD = cwd
 	i.cfg.SubagentsSystemAddendum = subagentsAddendum
+	if i.autoSwarmEnabled() {
+		i.managedAutoSwarmAddenda = autoSwarmAddenda(i.cfg)
+	} else {
+		i.managedAutoSwarmAddenda = nil
+	}
 	i.cfg.StartupContextPaths = append([]string(nil), startupContextPaths...)
 	i.view.StartupContextPaths = nil
 	if i.cfg.ShowInstructionsAtStartup != nil && *i.cfg.ShowInstructionsAtStartup {
@@ -6501,6 +6513,39 @@ func truncateForSummary(s string, n int) string {
 	return s[:n-3] + "..."
 }
 
+// autoSwarmAddenda returns the prompt blocks owned by the auto-swarm
+// toggle, in the same order Resolve appends them to a new agent.
+func autoSwarmAddenda(cfg InteractiveConfig) []string {
+	addenda := make([]string, 0, 2)
+	if addendum := strings.TrimSpace(cfg.SubagentsSystemAddendum); addendum != "" {
+		addenda = append(addenda, addendum)
+	}
+	if addendum := strings.TrimSpace(cfg.AutoSwarmSystemAddendum); addendum != "" {
+		addenda = append(addenda, addendum)
+	}
+	return addenda
+}
+
+func containsAutoSwarmAddendum(addenda []string, want string) bool {
+	for _, addendum := range addenda {
+		if addendum == want {
+			return true
+		}
+	}
+	return false
+}
+
+// removeLastAutoSwarmAddendum removes one occurrence of a block known to
+// have been appended by auto-swarm. Resolve appends owned blocks at the
+// end, so removing the last occurrence preserves an identical base block.
+func removeLastAutoSwarmAddendum(system, addendum string) (string, bool) {
+	idx := strings.LastIndex(system, addendum)
+	if idx < 0 {
+		return system, false
+	}
+	return system[:idx] + system[idx+len(addendum):], true
+}
+
 // applyAutoSwarmSystemPrompt appends (active=true) or strips
 // (active=false) the auto-swarm prompt blocks on the running agent.
 // The profile manifest and delegation guidance are managed together so
@@ -6509,39 +6554,31 @@ func (i *Interactive) applyAutoSwarmSystemPrompt(active bool) {
 	if i.agent == nil {
 		return
 	}
-	addenda := make([]string, 0, 2)
-	if addendum := strings.TrimSpace(i.cfg.SubagentsSystemAddendum); addendum != "" {
-		addenda = append(addenda, addendum)
-	}
-	if addendum := strings.TrimSpace(i.cfg.AutoSwarmSystemAddendum); addendum != "" {
-		addenda = append(addenda, addendum)
-	}
-	if len(addenda) == 0 {
-		return
-	}
-
-	sys := i.agent.System
+	addenda := autoSwarmAddenda(i.cfg)
 	if active {
+		sys := i.agent.System
 		for _, addendum := range addenda {
-			if strings.Contains(sys, addendum) {
+			if containsAutoSwarmAddendum(i.managedAutoSwarmAddenda, addendum) {
 				continue
 			}
 			if sys != "" && !strings.HasSuffix(sys, "\n\n") {
 				sys += "\n\n"
 			}
 			sys += addendum
+			i.managedAutoSwarmAddenda = append(i.managedAutoSwarmAddenda, addendum)
 		}
 		i.agent.System = sys
 		return
 	}
 
+	sys := i.agent.System
 	changed := false
-	for _, addendum := range addenda {
-		if strings.Contains(sys, addendum) {
-			changed = true
-			sys = strings.ReplaceAll(sys, addendum, "")
-		}
+	for idx := len(i.managedAutoSwarmAddenda) - 1; idx >= 0; idx-- {
+		var removed bool
+		sys, removed = removeLastAutoSwarmAddendum(sys, i.managedAutoSwarmAddenda[idx])
+		changed = changed || removed
 	}
+	i.managedAutoSwarmAddenda = nil
 	if changed {
 		i.agent.System = strings.TrimRight(sys, "\n") + "\n"
 	}

--- a/packages/agent/modes/swarm_dialog.go
+++ b/packages/agent/modes/swarm_dialog.go
@@ -275,6 +275,12 @@ func (d *swarmDialog) transcriptEditorCursorRow(width, popupRows, editorRowOffse
 	if a.Model != "" {
 		row++
 	}
+	if a.Subagent != "" {
+		row++
+	}
+	if a.Reasoning != "" {
+		row++
+	}
 	if a.Err != "" {
 		row++
 	}
@@ -1094,6 +1100,12 @@ func (d *swarmDialog) renderTranscript(th tui.Theme, width int) []string {
 			modelLine += " (" + a.Provider + ")"
 		}
 		header = append(header, "  "+th.FG256(th.Muted, modelLine))
+	}
+	if a.Subagent != "" {
+		header = append(header, "  "+th.FG256(th.Muted, "agent:  "+a.Subagent))
+	}
+	if a.Reasoning != "" {
+		header = append(header, "  "+th.FG256(th.Muted, "reasoning:  "+a.Reasoning))
 	}
 	if a.Err != "" {
 		header = append(header, "  "+th.FG256(th.Muted, "error:  "+a.Err))

--- a/packages/agent/modes/swarm_slash.go
+++ b/packages/agent/modes/swarm_slash.go
@@ -276,7 +276,7 @@ func parseSpawnFlags(s string) (model, provider, reasoning, subagent, task strin
 		f := fields[i]
 		switch {
 		case f == "--agent":
-			if i+1 < len(fields) {
+			if i+1 < len(fields) && !strings.HasPrefix(fields[i+1], "--") {
 				subagent = fields[i+1]
 				i += 2
 			} else {
@@ -291,7 +291,7 @@ func parseSpawnFlags(s string) (model, provider, reasoning, subagent, task strin
 			// Consume the flag even when no value follows so a
 			// dangling "--model" doesn't leak into the task. The
 			// caller surfaces "missing task" instead.
-			if i+1 < len(fields) {
+			if i+1 < len(fields) && !strings.HasPrefix(fields[i+1], "--") {
 				model = fields[i+1]
 				i += 2
 			} else {
@@ -303,7 +303,7 @@ func parseSpawnFlags(s string) (model, provider, reasoning, subagent, task strin
 			i++
 			continue
 		case f == "--provider":
-			if i+1 < len(fields) {
+			if i+1 < len(fields) && !strings.HasPrefix(fields[i+1], "--") {
 				provider = fields[i+1]
 				i += 2
 			} else {
@@ -315,7 +315,7 @@ func parseSpawnFlags(s string) (model, provider, reasoning, subagent, task strin
 			i++
 			continue
 		case f == "--reasoning" || f == "--thinking":
-			if i+1 < len(fields) {
+			if i+1 < len(fields) && !strings.HasPrefix(fields[i+1], "--") {
 				reasoning = fields[i+1]
 				i += 2
 			} else {

--- a/packages/agent/modes/swarm_slash.go
+++ b/packages/agent/modes/swarm_slash.go
@@ -13,8 +13,8 @@ import (
 //
 //	/swarm                       -> open the dashboard
 //	/swarm list                  -> open the dashboard
-//	/swarm new [--model M] [--provider P] <task...>
-//	                             -> spawn an agent (optionally pinned to a model)
+//	/swarm new [--agent A] [--model M] [--provider P] [--reasoning L] <task...>
+//	                             -> spawn an agent with optional profile/model overrides
 //	/swarm kill <id>             -> stop a running agent
 //	/swarm remove <id>           -> tear down a terminated agent
 //	/swarm logs <id>             -> open the scrollable transcript view
@@ -53,7 +53,7 @@ func (i *Interactive) runSwarm(ctx context.Context, args []string) {
 	// feed the dialog identical callbacks.
 	spawnAdapter := func(task, model, provider string) error {
 		_, err := i.cfg.Swarm.SpawnReq(ctx, swarm.SpawnRequest{
-			Task: task, Model: model, Provider: provider,
+			Task: task, Model: model, Provider: provider, Reasoning: i.cfg.Reasoning,
 		})
 		return err
 	}
@@ -93,30 +93,53 @@ func (i *Interactive) runSwarm(ctx context.Context, args []string) {
 			i.swarmStatus("", "/swarm new <task>: missing task")
 			return
 		}
-		// Permit `--model X --provider Y` flags before the task so
-		// scripts can pin a model without going through the dialog.
-		// Anything that isn't a recognised flag terminates parsing
-		// and the rest becomes the task; this keeps `/swarm new
-		// --model foo do a thing` and `/swarm new do --model thing`
-		// (where --model is part of the task) unambiguous — only
-		// leading flags are consumed.
-		model, provider, task := parseSpawnFlags(rest)
+		// Permit profile/model/provider/reasoning flags before the task
+		// so scripts can pin a child without going through the dialog.
+		// Anything that isn't a recognised flag terminates parsing and
+		// the rest becomes the task; only leading flags are consumed.
+		model, provider, reasoning, subagent, task := parseSpawnFlags(rest)
 		if task == "" {
-			i.swarmStatus("", "/swarm new: missing task (after any --model/--provider flags)")
+			i.swarmStatus("", "/swarm new: missing task (after any spawn flags)")
 			return
 		}
+		if subagent != "" && i.cfg.ResolveSubagent != nil {
+			profile, err := i.cfg.ResolveSubagent(subagent)
+			if err != nil {
+				i.swarmStatus("", "spawn: "+err.Error())
+				return
+			}
+			if profile == nil {
+				i.swarmStatus("", "spawn: unknown subagent profile "+subagent)
+				return
+			}
+			subagent = profile.Name
+			if model == "" && provider == "" {
+				profileProvider, profileModel := profile.ModelSelection()
+				if profileProvider != "" && profileModel != "" {
+					provider, model = profileProvider, profileModel
+				}
+			}
+			if reasoning == "" {
+				reasoning = profile.Thinking
+			}
+		}
+		if reasoning == "" {
+			reasoning = i.cfg.Reasoning
+		}
 		a, err := i.cfg.Swarm.SpawnReq(ctx, swarm.SpawnRequest{
-			Task: task, Model: model, Provider: provider,
+			Task: task, Model: model, Provider: provider, Reasoning: reasoning, Subagent: subagent,
 		})
 		if err != nil {
 			i.swarmStatus("", "spawn: "+err.Error())
 			return
 		}
-		if model != "" {
-			i.swarmStatus("spawned "+a.ID+" (model "+model+")", "")
-		} else {
-			i.swarmStatus("spawned "+a.ID, "")
+		status := "spawned " + a.ID
+		if subagent != "" {
+			status += " (agent " + subagent + ")"
+		} else if model != "" {
+			status += " (model " + model + ")"
 		}
+		i.swarmStatus(status, "")
 	case "kill", "stop":
 		if rest == "" {
 			i.swarmStatus("", "/swarm kill <id>: missing id")
@@ -220,24 +243,40 @@ func (i *Interactive) runSwarm(ctx context.Context, args []string) {
 	}
 }
 
-// parseSpawnFlags consumes any leading `--model X` / `--provider Y`
-// flags from s and returns them along with the remaining task body.
+// parseSpawnFlags consumes leading profile/model/provider/reasoning flags
+// from s and returns them along with the remaining task body.
 // We deliberately only honour LEADING flags so a task like "check
 // --model lookup" doesn't accidentally swallow part of its prose as
 // the model name.
 //
 // Recognised forms:
 //
+//	--agent X            two-token form
+//	--agent=X            single-token form
 //	--model X            two-token form
 //	--model=X            single-token form
 //	--provider X         two-token form
 //	--provider=X         single-token form
-func parseSpawnFlags(s string) (model, provider, task string) {
+//	--reasoning X        two-token form (also --thinking)
+//	--reasoning=X        single-token form
+func parseSpawnFlags(s string) (model, provider, reasoning, subagent, task string) {
 	fields := strings.Fields(s)
 	i := 0
 	for i < len(fields) {
 		f := fields[i]
 		switch {
+		case f == "--agent":
+			if i+1 < len(fields) {
+				subagent = fields[i+1]
+				i += 2
+			} else {
+				i++
+			}
+			continue
+		case strings.HasPrefix(f, "--agent="):
+			subagent = strings.TrimPrefix(f, "--agent=")
+			i++
+			continue
 		case f == "--model":
 			// Consume the flag even when no value follows so a
 			// dangling "--model" doesn't leak into the task. The
@@ -263,6 +302,22 @@ func parseSpawnFlags(s string) (model, provider, task string) {
 			continue
 		case strings.HasPrefix(f, "--provider="):
 			provider = strings.TrimPrefix(f, "--provider=")
+			i++
+			continue
+		case f == "--reasoning" || f == "--thinking":
+			if i+1 < len(fields) {
+				reasoning = fields[i+1]
+				i += 2
+			} else {
+				i++
+			}
+			continue
+		case strings.HasPrefix(f, "--reasoning="):
+			reasoning = strings.TrimPrefix(f, "--reasoning=")
+			i++
+			continue
+		case strings.HasPrefix(f, "--thinking="):
+			reasoning = strings.TrimPrefix(f, "--thinking=")
 			i++
 			continue
 		}

--- a/packages/agent/modes/swarm_slash.go
+++ b/packages/agent/modes/swarm_slash.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/patriceckhart/zot/packages/agent/swarm"
+	"github.com/patriceckhart/zot/packages/provider"
 	"github.com/patriceckhart/zot/packages/tui"
 )
 
@@ -126,6 +127,14 @@ func (i *Interactive) runSwarm(ctx context.Context, args []string) {
 		if reasoning == "" {
 			reasoning = i.cfg.Reasoning
 		}
+		if reasoning != "" {
+			normalizedReasoning, err := normalizeSpawnReasoning(reasoning)
+			if err != nil {
+				i.swarmStatus("", "spawn: "+err.Error())
+				return
+			}
+			reasoning = normalizedReasoning
+		}
 		a, err := i.cfg.Swarm.SpawnReq(ctx, swarm.SpawnRequest{
 			Task: task, Model: model, Provider: provider, Reasoning: reasoning, Subagent: subagent,
 		})
@@ -243,22 +252,23 @@ func (i *Interactive) runSwarm(ctx context.Context, args []string) {
 	}
 }
 
+// normalizeSpawnReasoning validates and canonicalizes the reasoning levels
+// accepted by ParseArgs before a child process is launched.
+func normalizeSpawnReasoning(value string) (string, error) {
+	raw := strings.ToLower(strings.TrimSpace(value))
+	switch raw {
+	case "", "off":
+		return raw, nil
+	case "minimal", "minimum", "low", "medium", "high", "xhigh", "maximum", "max":
+		return provider.NormalizeReasoning(raw), nil
+	default:
+		return "", fmt.Errorf("reasoning must be off|minimum|low|medium|high|xhigh|max")
+	}
+}
+
 // parseSpawnFlags consumes leading profile/model/provider/reasoning flags
-// from s and returns them along with the remaining task body.
-// We deliberately only honour LEADING flags so a task like "check
-// --model lookup" doesn't accidentally swallow part of its prose as
-// the model name.
-//
-// Recognised forms:
-//
-//	--agent X            two-token form
-//	--agent=X            single-token form
-//	--model X            two-token form
-//	--model=X            single-token form
-//	--provider X         two-token form
-//	--provider=X         single-token form
-//	--reasoning X        two-token form (also --thinking)
-//	--reasoning=X        single-token form
+// using both separate-value and equals forms. Flags after the task remain
+// part of the task text.
 func parseSpawnFlags(s string) (model, provider, reasoning, subagent, task string) {
 	fields := strings.Fields(s)
 	i := 0

--- a/packages/agent/modes/swarm_slash_test.go
+++ b/packages/agent/modes/swarm_slash_test.go
@@ -177,26 +177,29 @@ func TestRunSwarmSendDeliversToAgentInbox(t *testing.T) {
 
 func TestParseSpawnFlags(t *testing.T) {
 	cases := []struct {
-		in                  string
-		wantModel, wantProv string
-		wantTask            string
+		in                          string
+		wantModel, wantProv         string
+		wantReasoning, wantSubagent string
+		wantTask                    string
 	}{
-		{"do x", "", "", "do x"},
-		{"--model claude do x", "claude", "", "do x"},
-		{"--model=claude do x", "claude", "", "do x"},
-		{"--provider openai --model gpt-5 do x", "gpt-5", "openai", "do x"},
-		{"--provider=openai --model=gpt-5 do x", "gpt-5", "openai", "do x"},
+		{"do x", "", "", "", "", "do x"},
+		{"--model claude do x", "claude", "", "", "", "do x"},
+		{"--model=claude do x", "claude", "", "", "", "do x"},
+		{"--provider openai --model gpt-5 do x", "gpt-5", "openai", "", "", "do x"},
+		{"--provider=openai --model=gpt-5 do x", "gpt-5", "openai", "", "", "do x"},
+		{"--agent reviewer --reasoning high review auth", "", "", "high", "reviewer", "review auth"},
+		{"--thinking=max do x", "", "", "max", "", "do x"},
 		// Only LEADING flags are consumed.
-		{"do --model x", "", "", "do --model x"},
+		{"do --model x", "", "", "", "", "do --model x"},
 		// Missing value: --model with no follow-up token leaves model empty
 		// and the next field starts the task.
-		{"--model", "", "", ""},
+		{"--model", "", "", "", "", ""},
 	}
 	for _, c := range cases {
-		m, p, task := parseSpawnFlags(c.in)
-		if m != c.wantModel || p != c.wantProv || task != c.wantTask {
-			t.Errorf("parseSpawnFlags(%q) = (%q,%q,%q); want (%q,%q,%q)",
-				c.in, m, p, task, c.wantModel, c.wantProv, c.wantTask)
+		m, p, r, a, task := parseSpawnFlags(c.in)
+		if m != c.wantModel || p != c.wantProv || r != c.wantReasoning || a != c.wantSubagent || task != c.wantTask {
+			t.Errorf("parseSpawnFlags(%q) = (%q,%q,%q,%q,%q); want (%q,%q,%q,%q,%q)",
+				c.in, m, p, r, a, task, c.wantModel, c.wantProv, c.wantReasoning, c.wantSubagent, c.wantTask)
 		}
 	}
 }

--- a/packages/agent/modes/swarm_slash_test.go
+++ b/packages/agent/modes/swarm_slash_test.go
@@ -175,6 +175,31 @@ func TestRunSwarmSendDeliversToAgentInbox(t *testing.T) {
 	}
 }
 
+func TestNormalizeSpawnReasoning(t *testing.T) {
+	cases := []struct {
+		in, want string
+		ok       bool
+	}{
+		{in: "OFF", want: "off", ok: true},
+		{in: "minimal", want: "minimum", ok: true},
+		{in: "maximum", want: "xhigh", ok: true},
+		{in: "MAX", want: "max", ok: true},
+		{in: "bogus", ok: false},
+	}
+	for _, tc := range cases {
+		got, err := normalizeSpawnReasoning(tc.in)
+		if tc.ok {
+			if err != nil || got != tc.want {
+				t.Errorf("normalizeSpawnReasoning(%q) = %q, %v; want %q", tc.in, got, err, tc.want)
+			}
+			continue
+		}
+		if err == nil {
+			t.Errorf("normalizeSpawnReasoning(%q) succeeded with %q; want error", tc.in, got)
+		}
+	}
+}
+
 func TestParseSpawnFlags(t *testing.T) {
 	cases := []struct {
 		in                          string

--- a/packages/agent/modes/swarm_slash_test.go
+++ b/packages/agent/modes/swarm_slash_test.go
@@ -213,6 +213,8 @@ func TestParseSpawnFlags(t *testing.T) {
 		{"--provider openai --model gpt-5 do x", "gpt-5", "openai", "", "", "do x"},
 		{"--provider=openai --model=gpt-5 do x", "gpt-5", "openai", "", "", "do x"},
 		{"--agent reviewer --reasoning high review auth", "", "", "high", "reviewer", "review auth"},
+		{"--agent --reasoning high review auth", "", "", "high", "", "review auth"},
+		{"--reasoning --agent reviewer review auth", "", "", "", "reviewer", "review auth"},
 		{"--thinking=max do x", "", "", "max", "", "do x"},
 		// Only LEADING flags are consumed.
 		{"do --model x", "", "", "", "", "do --model x"},

--- a/packages/agent/settings_store.go
+++ b/packages/agent/settings_store.go
@@ -183,7 +183,7 @@ func AutoSwarmEnabled() bool {
 // by name. Kept short so it doesn't bloat the cached prompt prefix.
 const AutoSwarmSystemAddendum = `Auto-swarm is enabled. You have a swarm_spawn tool that forks background sub-agents working in parallel in this same working directory.
 
-Use it proactively when the user's request naturally splits into independent sub-tasks that can run concurrently (e.g. "refactor module A and module B", "write the implementation and the tests", "investigate three separate files"). Spawn one sub-agent per independent sub-task with a self-contained task description (sub-agents start with no context from this conversation). Continue working on the remaining or coordinating work yourself in parallel; do not wait for sub-agents to finish before responding. Briefly tell the user which sub-agents you spawned and what each is doing.
+Use it proactively when the user's request naturally splits into independent sub-tasks that can run concurrently (e.g. "refactor module A and module B", "write the implementation and the tests", "investigate three separate files"). Spawn one sub-agent per independent sub-task with a self-contained task description (sub-agents start with no context from this conversation). If [subagents_list] is present, choose the named profile whose description best matches the task and pass its name as the tool's agent field. Continue working on the remaining or coordinating work yourself in parallel; do not wait for sub-agents to finish before responding. Briefly tell the user which sub-agents you spawned and what each is doing.
 
 Do NOT use swarm_spawn for trivial single-step work, for tasks that depend on each other sequentially, or when the user explicitly asked you to do the work yourself.
 

--- a/packages/agent/subagents/profiles.go
+++ b/packages/agent/subagents/profiles.go
@@ -1,0 +1,354 @@
+// Package subagents discovers named agent profiles that can be selected by
+// zot's swarm supervisor. Profiles use the common markdown/frontmatter layout:
+// a YAML-like metadata block followed by the agent's system prompt.
+//
+// Discovery prefers explicitly configured directories, then the shared
+// ~/.agents/agents directory, and finally the optional ~/.pi/agent/agents
+// compatibility directory. Profiles are metadata plus instructions; the main
+// agent sees only the compact manifest, while a selected child loads the full
+// profile itself.
+package subagents
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const maxProfileBytes = 1 << 20
+
+// Profile is one discovered named subagent definition.
+type Profile struct {
+	Name         string
+	Description  string
+	SystemPrompt string
+	Tools        []string
+	Model        string
+	Provider     string
+	Thinking     string
+
+	// SystemPromptMode is "append" (the default) or "replace".
+	SystemPromptMode string
+
+	// Nil means the profile did not specify the inheritance behavior.
+	InheritProjectContext *bool
+	InheritSkills         *bool
+
+	Path   string
+	Source string
+}
+
+// Discover returns profiles in precedence order, sorted by name. A profile
+// with the same name in a higher-priority directory shadows lower-priority
+// copies. Missing directories are normal and do not produce errors.
+func Discover(cwd, userHome string) ([]*Profile, []error) {
+	seen := make(map[string]*Profile)
+	var errs []error
+
+	for _, loc := range searchDirs(cwd, userHome) {
+		entries, err := os.ReadDir(loc.dir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				errs = append(errs, fmt.Errorf("read subagent directory %s: %w", loc.dir, err))
+			}
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.Type().IsRegular() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+				continue
+			}
+			path := filepath.Join(loc.dir, entry.Name())
+			profile, err := load(path, loc.label)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					errs = append(errs, fmt.Errorf("read subagent profile %s: %w", path, err))
+				}
+				continue
+			}
+			if !validName(profile.Name) || profile.SystemPrompt == "" {
+				continue
+			}
+			if _, exists := seen[profile.Name]; exists {
+				continue
+			}
+			seen[profile.Name] = profile
+		}
+	}
+
+	out := make([]*Profile, 0, len(seen))
+	for _, profile := range seen {
+		out = append(out, profile)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, errs
+}
+
+// Find returns a profile by its exact name, or nil when it is unavailable.
+func Find(profiles []*Profile, name string) *Profile {
+	name = strings.TrimSpace(name)
+	for _, profile := range profiles {
+		if profile != nil && profile.Name == name {
+			return profile
+		}
+	}
+	return nil
+}
+
+// ModelSelection splits a provider-qualified model value such as
+// "openai-codex/gpt-5.6-luna". A model id may itself contain slashes, so only
+// the first slash is treated as the provider separator.
+func (p *Profile) ModelSelection() (provider, model string) {
+	if p == nil {
+		return "", ""
+	}
+	provider = strings.TrimSpace(p.Provider)
+	model = strings.TrimSpace(p.Model)
+	if provider == "" {
+		if before, after, ok := strings.Cut(model, "/"); ok {
+			provider, model = strings.TrimSpace(before), strings.TrimSpace(after)
+		}
+	}
+	return provider, model
+}
+
+// SystemPromptAddendum renders the compact [subagents_list] manifest for the
+// parent model. Full profile bodies are intentionally omitted: the selected
+// child loads its own instructions, and keeping them out of every parent turn
+// avoids unnecessary context and accidental instruction mixing.
+func SystemPromptAddendum(profiles []*Profile) string {
+	if len(profiles) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("[subagents_list]\n")
+	sb.WriteString("Named subagents available to swarm_spawn. Choose the profile whose description best matches the independent task and pass its name as the tool's agent field. The selected profile's instructions, model, thinking level, and tool limits are applied to the child.\n")
+	for _, profile := range profiles {
+		if profile == nil {
+			continue
+		}
+		name := manifestValue(profile.Name)
+		description := manifestValue(profile.Description)
+		if description == "" {
+			description = "(no description)"
+		}
+		metadata := make([]string, 0, 4)
+		if model := manifestValue(profile.Model); model != "" {
+			metadata = append(metadata, "model="+model)
+		}
+		if provider := manifestValue(profile.Provider); provider != "" {
+			metadata = append(metadata, "provider="+provider)
+		}
+		if thinking := manifestValue(profile.Thinking); thinking != "" {
+			metadata = append(metadata, "thinking="+thinking)
+		}
+		if len(profile.Tools) > 0 {
+			metadata = append(metadata, "tools="+manifestValue(strings.Join(profile.Tools, ",")))
+		}
+		if len(metadata) > 0 {
+			fmt.Fprintf(&sb, "- %s [%s]: %s\n", name, strings.Join(metadata, " "), description)
+		} else {
+			fmt.Fprintf(&sb, "- %s: %s\n", name, description)
+		}
+	}
+	sb.WriteString("[/subagents_list]")
+	return sb.String()
+}
+
+type location struct {
+	dir   string
+	label string
+}
+
+func searchDirs(cwd, userHome string) []location {
+	var out []location
+	add := func(dir, label string) {
+		if strings.TrimSpace(dir) != "" {
+			out = append(out, location{dir: dir, label: label})
+		}
+	}
+	if extra := os.Getenv("ZOT_AGENT_PROFILES"); extra != "" {
+		for _, dir := range filepath.SplitList(extra) {
+			add(dir, "configured")
+		}
+	}
+	if userHome != "" {
+		add(filepath.Join(userHome, ".agents", "agents"), "global (agents)")
+		// This is an additional compatibility location. The shared .agents
+		// path above remains zot's documented default.
+		add(filepath.Join(userHome, ".pi", "agent", "agents"), "global (pi)")
+	}
+	return out
+}
+
+func load(path, source string) (*Profile, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file")
+	}
+	if info.Size() > maxProfileBytes {
+		return nil, fmt.Errorf("profile is larger than %d bytes", maxProfileBytes)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	front, body := splitFrontmatter(string(raw))
+	values, lists := parseFrontmatter(front)
+	name := unquote(values["name"])
+	if name == "" {
+		name = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+	thinking := unquote(values["thinking"])
+	if thinking == "" {
+		thinking = unquote(values["reasoning"])
+	}
+	profile := &Profile{
+		Name:         strings.TrimSpace(name),
+		Description:  strings.TrimSpace(unquote(values["description"])),
+		SystemPrompt: strings.TrimSpace(body),
+		Tools:        lists["tools"],
+		Model:        unquote(values["model"]),
+		Provider:     unquote(values["provider"]),
+		Thinking:     thinking,
+		Path:         path,
+		Source:       source,
+	}
+	profile.SystemPromptMode = "append"
+	if strings.EqualFold(unquote(values["systempromptmode"]), "replace") {
+		profile.SystemPromptMode = "replace"
+	}
+	if value, ok := parseOptionalBool(values["inheritprojectcontext"]); ok {
+		profile.InheritProjectContext = &value
+	}
+	if value, ok := parseOptionalBool(values["inheritskills"]); ok {
+		profile.InheritSkills = &value
+	}
+	return profile, nil
+}
+
+func splitFrontmatter(raw string) (front, body string) {
+	rest := strings.TrimLeft(raw, " \t\r\n")
+	firstEnd := strings.IndexByte(rest, '\n')
+	if firstEnd < 0 || strings.TrimSpace(rest[:firstEnd]) != "---" {
+		return "", raw
+	}
+	rest = rest[firstEnd+1:]
+	for offset := 0; offset <= len(rest); {
+		rel := strings.Index(rest[offset:], "\n---")
+		if rel < 0 {
+			// A document that starts a frontmatter block but never closes
+			// it is malformed, not a body-only profile.
+			return "", ""
+		}
+		end := offset + rel
+		after := end + len("\n---")
+		if after == len(rest) || rest[after] == '\n' || rest[after] == '\r' {
+			return rest[:end], strings.TrimLeft(rest[after:], " \t\r\n")
+		}
+		offset = after
+	}
+	return "", raw
+}
+
+func parseFrontmatter(front string) (map[string]string, map[string][]string) {
+	values := make(map[string]string)
+	lists := make(map[string][]string)
+	lines := strings.Split(front, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			continue
+		}
+		colon := strings.IndexByte(trimmed, ':')
+		if colon < 0 {
+			continue
+		}
+		key := normalizeKey(trimmed[:colon])
+		value := strings.TrimSpace(trimmed[colon+1:])
+		if value == "" {
+			var items []string
+			for j := i + 1; j < len(lines); j++ {
+				next := strings.TrimSpace(lines[j])
+				if next == "" {
+					continue
+				}
+				if !strings.HasPrefix(next, "-") || (len(lines[j]) > 0 && !strings.HasPrefix(lines[j], " ") && !strings.HasPrefix(lines[j], "\t")) {
+					break
+				}
+				items = append(items, unquote(strings.TrimSpace(strings.TrimPrefix(next, "-"))))
+				i = j
+			}
+			if len(items) > 0 {
+				lists[key] = items
+			}
+			continue
+		}
+		if key == "tools" {
+			lists[key] = parseList(value)
+			continue
+		}
+		values[key] = unquote(value)
+	}
+	return values, lists
+}
+
+func normalizeKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.ReplaceAll(key, "-", "")
+	key = strings.ReplaceAll(key, "_", "")
+	return key
+}
+
+func parseList(value string) []string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "[")
+	value = strings.TrimSuffix(value, "]")
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if item := strings.TrimSpace(unquote(part)); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func parseOptionalBool(value string) (bool, bool) {
+	parsed, err := strconv.ParseBool(strings.TrimSpace(unquote(value)))
+	return parsed, err == nil
+}
+
+func validName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || len(name) > 128 {
+		return false
+	}
+	for _, r := range name {
+		if r == '/' || r == '\\' || r == '\x00' || r < 0x20 {
+			return false
+		}
+	}
+	return true
+}
+
+func manifestValue(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func unquote(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'')) {
+		return value[1 : len(value)-1]
+	}
+	return value
+}

--- a/packages/agent/subagents/profiles.go
+++ b/packages/agent/subagents/profiles.go
@@ -204,9 +204,16 @@ func load(path, source string) (*Profile, error) {
 	if name == "" {
 		name = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	}
-	thinking := unquote(values["thinking"])
+	thinking, err := parseThinkingValue(values["thinking"], "thinking")
+	if err != nil {
+		return nil, err
+	}
+	reasoning, err := parseThinkingValue(values["reasoning"], "reasoning")
+	if err != nil {
+		return nil, err
+	}
 	if thinking == "" {
-		thinking = unquote(values["reasoning"])
+		thinking = reasoning
 	}
 	profile := &Profile{
 		Name:         strings.TrimSpace(name),
@@ -220,13 +227,27 @@ func load(path, source string) (*Profile, error) {
 		Source:       source,
 	}
 	profile.SystemPromptMode = "append"
-	if strings.EqualFold(unquote(values["systempromptmode"]), "replace") {
-		profile.SystemPromptMode = "replace"
+	if mode, ok := values["systempromptmode"]; ok {
+		switch strings.ToLower(strings.TrimSpace(unquote(mode))) {
+		case "", "append":
+		case "replace":
+			profile.SystemPromptMode = "replace"
+		default:
+			return nil, fmt.Errorf("systemPromptMode must be append or replace")
+		}
 	}
-	if value, ok := parseOptionalBool(values["inheritprojectcontext"]); ok {
+	if raw, ok := values["inheritprojectcontext"]; ok {
+		value, parsed := parseOptionalBool(raw)
+		if !parsed {
+			return nil, fmt.Errorf("inheritProjectContext must be true or false")
+		}
 		profile.InheritProjectContext = &value
 	}
-	if value, ok := parseOptionalBool(values["inheritskills"]); ok {
+	if raw, ok := values["inheritskills"]; ok {
+		value, parsed := parseOptionalBool(raw)
+		if !parsed {
+			return nil, fmt.Errorf("inheritSkills must be true or false")
+		}
 		profile.InheritSkills = &value
 	}
 	return profile, nil
@@ -321,6 +342,23 @@ func parseList(value string) []string {
 		}
 	}
 	return out
+}
+
+func parseThinkingValue(value, field string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(unquote(value))) {
+	case "":
+		return "", nil
+	case "off":
+		return "off", nil
+	case "minimal", "minimum":
+		return "minimum", nil
+	case "low", "medium", "high", "xhigh", "max":
+		return strings.ToLower(strings.TrimSpace(unquote(value))), nil
+	case "maximum":
+		return "xhigh", nil
+	default:
+		return "", fmt.Errorf("%s must be off|minimum|low|medium|high|xhigh|max", field)
+	}
 }
 
 func parseOptionalBool(value string) (bool, bool) {

--- a/packages/agent/subagents/profiles.go
+++ b/packages/agent/subagents/profiles.go
@@ -198,7 +198,10 @@ func load(path, source string) (*Profile, error) {
 	if err != nil {
 		return nil, err
 	}
-	front, body := splitFrontmatter(string(raw))
+	front, body, err := splitFrontmatter(string(raw))
+	if err != nil {
+		return nil, err
+	}
 	values, lists := parseFrontmatter(front)
 	name := unquote(values["name"])
 	if name == "" {
@@ -253,11 +256,11 @@ func load(path, source string) (*Profile, error) {
 	return profile, nil
 }
 
-func splitFrontmatter(raw string) (front, body string) {
+func splitFrontmatter(raw string) (front, body string, err error) {
 	rest := strings.TrimLeft(raw, " \t\r\n")
 	firstEnd := strings.IndexByte(rest, '\n')
 	if firstEnd < 0 || strings.TrimSpace(rest[:firstEnd]) != "---" {
-		return "", raw
+		return "", raw, nil
 	}
 	rest = rest[firstEnd+1:]
 	for offset := 0; offset <= len(rest); {
@@ -265,16 +268,16 @@ func splitFrontmatter(raw string) (front, body string) {
 		if rel < 0 {
 			// A document that starts a frontmatter block but never closes
 			// it is malformed, not a body-only profile.
-			return "", ""
+			return "", "", fmt.Errorf("frontmatter: missing closing delimiter")
 		}
 		end := offset + rel
 		after := end + len("\n---")
 		if after == len(rest) || rest[after] == '\n' || rest[after] == '\r' {
-			return rest[:end], strings.TrimLeft(rest[after:], " \t\r\n")
+			return rest[:end], strings.TrimLeft(rest[after:], " \t\r\n"), nil
 		}
 		offset = after
 	}
-	return "", raw
+	return "", raw, nil
 }
 
 func parseFrontmatter(front string) (map[string]string, map[string][]string) {

--- a/packages/agent/subagents/profiles_test.go
+++ b/packages/agent/subagents/profiles_test.go
@@ -1,6 +1,7 @@
 package subagents
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -96,6 +97,28 @@ No.
 	}
 	if len(profiles) != 1 || profiles[0].Description != "Configured reviewer" {
 		t.Fatalf("configured precedence = %#v", profiles)
+	}
+}
+
+func TestLoadRejectsInvalidClosedSchemaMetadata(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+	}{
+		{name: "invalid-thinking", field: "thinking: extreme"},
+		{name: "invalid-reasoning", field: "reasoning: extreme"},
+		{name: "invalid-prompt-mode", field: "systemPromptMode: merge"},
+		{name: "invalid-project-context", field: "inheritProjectContext: sometimes"},
+		{name: "invalid-skills", field: "inheritSkills: sometimes"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "profile.md")
+			writeProfile(t, path, fmt.Sprintf("---\nname: test\n%s\n---\nInstructions.\n", tc.field))
+			if _, err := load(path, "test"); err == nil {
+				t.Fatalf("load succeeded for invalid metadata %q", tc.field)
+			}
+		})
 	}
 }
 

--- a/packages/agent/subagents/profiles_test.go
+++ b/packages/agent/subagents/profiles_test.go
@@ -1,0 +1,147 @@
+package subagents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverLoadsGlobalAgentsProfilesAndPiFallback(t *testing.T) {
+	home := t.TempDir()
+	agentsDir := filepath.Join(home, ".agents", "agents")
+	piDir := filepath.Join(home, ".pi", "agent", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeProfile(t, filepath.Join(agentsDir, "reviewer.md"), `---
+name: reviewer
+description: Read-only code reviewer
+tools: read
+model: openai-codex/gpt-5.6-luna
+thinking: max
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+---
+Review the requested scope without editing it.
+`)
+	writeProfile(t, filepath.Join(piDir, "implementer.md"), `---
+name: implementer
+description: Primary implementation agent
+tools: [read, bash, edit, write]
+model: openai-codex/gpt-5.6-luna
+thinking: xhigh
+---
+Implement the requested change.
+`)
+
+	profiles, errs := Discover("", home)
+	if len(errs) != 0 {
+		t.Fatalf("Discover errors = %v", errs)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("profiles = %d, want 2: %#v", len(profiles), profiles)
+	}
+	if profiles[0].Name != "implementer" || profiles[1].Name != "reviewer" {
+		t.Fatalf("profiles not sorted by name: %#v", profiles)
+	}
+	reviewer := Find(profiles, "reviewer")
+	if reviewer == nil {
+		t.Fatal("reviewer profile missing")
+	}
+	if reviewer.SystemPromptMode != "replace" {
+		t.Fatalf("system prompt mode = %q, want replace", reviewer.SystemPromptMode)
+	}
+	if reviewer.Model != "openai-codex/gpt-5.6-luna" || reviewer.Thinking != "max" {
+		t.Fatalf("profile metadata = %#v", reviewer)
+	}
+	if reviewer.InheritProjectContext == nil || *reviewer.InheritProjectContext {
+		t.Fatalf("inherit project context = %#v, want false", reviewer.InheritProjectContext)
+	}
+	if reviewer.InheritSkills == nil || *reviewer.InheritSkills {
+		t.Fatalf("inherit skills = %#v, want false", reviewer.InheritSkills)
+	}
+}
+
+func TestDiscoverConfiguredDirectoryWinsAndRejectsUnsafeNames(t *testing.T) {
+	configured := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("ZOT_AGENT_PROFILES", configured)
+	writeProfile(t, filepath.Join(configured, "reviewer.md"), `---
+name: reviewer
+description: Configured reviewer
+---
+Configured instructions.
+`)
+	writeProfile(t, filepath.Join(filepath.Join(home, ".agents", "agents"), "reviewer.md"), `---
+name: reviewer
+description: Global reviewer
+---
+Global instructions.
+`)
+	writeProfile(t, filepath.Join(configured, "unsafe.md"), `---
+name: ../unsafe
+description: Should not load
+---
+No.
+`)
+
+	profiles, errs := Discover("", home)
+	if len(errs) != 0 {
+		t.Fatalf("Discover errors = %v", errs)
+	}
+	if len(profiles) != 1 || profiles[0].Description != "Configured reviewer" {
+		t.Fatalf("configured precedence = %#v", profiles)
+	}
+}
+
+func TestProfileModelSelection(t *testing.T) {
+	profile := &Profile{Model: "openrouter/anthropic/claude-sonnet"}
+	provider, model := profile.ModelSelection()
+	if provider != "openrouter" || model != "anthropic/claude-sonnet" {
+		t.Fatalf("selection = (%q, %q)", provider, model)
+	}
+
+	profile = &Profile{Provider: "openai", Model: "gpt-5"}
+	provider, model = profile.ModelSelection()
+	if provider != "openai" || model != "gpt-5" {
+		t.Fatalf("explicit selection = (%q, %q)", provider, model)
+	}
+}
+
+func TestSystemPromptAddendumIsCompactAndDoesNotExposeBodyOrPath(t *testing.T) {
+	profiles := []*Profile{{
+		Name:         "reviewer",
+		Description:  "Read-only\nreviewer",
+		SystemPrompt: "secret instructions that belong only to the child",
+		Model:        "openai-codex/gpt-5",
+		Thinking:     "max",
+		Tools:        []string{"read", "bash"},
+		Path:         "/private/profile.md",
+	}}
+	got := SystemPromptAddendum(profiles)
+	for _, want := range []string{"[subagents_list]", "[/subagents_list]", "reviewer", "Read-only reviewer", "model=openai-codex/gpt-5", "thinking=max"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("addendum missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{"secret instructions", "/private/profile.md", "\nreviewer"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("addendum contains %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+func writeProfile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/packages/agent/subagents/profiles_test.go
+++ b/packages/agent/subagents/profiles_test.go
@@ -100,6 +100,16 @@ No.
 	}
 }
 
+func TestLoadRejectsUnclosedFrontmatter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile.md")
+	if err := os.WriteFile(path, []byte("---\nname: reviewer\nInstructions without a closing delimiter.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := load(path, "test"); err == nil || !strings.Contains(err.Error(), "missing closing delimiter") {
+		t.Fatalf("load error = %v, want missing closing delimiter", err)
+	}
+}
+
 func TestLoadRejectsInvalidClosedSchemaMetadata(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/packages/agent/swarm/agent.go
+++ b/packages/agent/swarm/agent.go
@@ -22,8 +22,10 @@ type Agent struct {
 	// the child resolves on its own from config / env / flags" —
 	// the historical behaviour. Persisted in meta.json so Resume
 	// keeps using the same model across zot restarts.
-	Model    string
-	Provider string
+	Model     string
+	Provider  string
+	Reasoning string
+	Subagent  string
 
 	// SessionID, when non-empty, scopes the agent to a particular
 	// host zot session: the dashboard only surfaces agents whose

--- a/packages/agent/swarm/persist.go
+++ b/packages/agent/swarm/persist.go
@@ -353,6 +353,7 @@ func (f *Swarm) Resume(ctx context.Context, id string) (*Agent, error) {
 		Dir: existing.Dir, Started: existing.Started,
 		Model: existing.Model, Provider: existing.Provider,
 		Reasoning: existing.Reasoning, Subagent: existing.Subagent,
+		SessionID: existing.SessionID,
 		InboxPath: inboxPath, EventLogPath: existing.EventLogPath,
 		SessionPath: existing.SessionPath,
 	}
@@ -366,6 +367,7 @@ func (f *Swarm) Resume(ctx context.Context, id string) (*Agent, error) {
 		Provider:     m.Provider,
 		Reasoning:    m.Reasoning,
 		Subagent:     m.Subagent,
+		SessionID:    m.SessionID,
 		InboxPath:    m.InboxPath,
 		EventLogPath: m.EventLogPath,
 		SessionPath:  m.SessionPath,

--- a/packages/agent/swarm/persist.go
+++ b/packages/agent/swarm/persist.go
@@ -44,6 +44,8 @@ type agentMeta struct {
 	Started      time.Time `json:"started"`
 	Model        string    `json:"model,omitempty"`
 	Provider     string    `json:"provider,omitempty"`
+	Reasoning    string    `json:"reasoning,omitempty"`
+	Subagent     string    `json:"subagent,omitempty"`
 	InboxPath    string    `json:"inbox_path"`
 	EventLogPath string    `json:"event_log_path"`
 	SessionPath  string    `json:"session_path"`
@@ -71,6 +73,8 @@ func writeAgentMeta(stateDir string, a *Agent) error {
 		Started:      a.Started,
 		Model:        a.Model,
 		Provider:     a.Provider,
+		Reasoning:    a.Reasoning,
+		Subagent:     a.Subagent,
 		InboxPath:    a.InboxPath,
 		EventLogPath: a.EventLogPath,
 		SessionPath:  a.SessionPath,
@@ -205,6 +209,8 @@ func (f *Swarm) buildDetachedAgent(m agentMeta) *Agent {
 		Started:      m.Started,
 		Model:        m.Model,
 		Provider:     m.Provider,
+		Reasoning:    m.Reasoning,
+		Subagent:     m.Subagent,
 		InboxPath:    m.InboxPath,
 		EventLogPath: m.EventLogPath,
 		SessionPath:  m.SessionPath,
@@ -346,6 +352,7 @@ func (f *Swarm) Resume(ctx context.Context, id string) (*Agent, error) {
 		ID: existing.ID, Task: existing.Task,
 		Dir: existing.Dir, Started: existing.Started,
 		Model: existing.Model, Provider: existing.Provider,
+		Reasoning: existing.Reasoning, Subagent: existing.Subagent,
 		InboxPath: inboxPath, EventLogPath: existing.EventLogPath,
 		SessionPath: existing.SessionPath,
 	}
@@ -357,6 +364,8 @@ func (f *Swarm) Resume(ctx context.Context, id string) (*Agent, error) {
 		Started:      m.Started,
 		Model:        m.Model,
 		Provider:     m.Provider,
+		Reasoning:    m.Reasoning,
+		Subagent:     m.Subagent,
 		InboxPath:    m.InboxPath,
 		EventLogPath: m.EventLogPath,
 		SessionPath:  m.SessionPath,

--- a/packages/agent/swarm/persist_test.go
+++ b/packages/agent/swarm/persist_test.go
@@ -538,16 +538,17 @@ func TestSpawnReqPersistsModel(t *testing.T) {
 	})
 	a, err := f.SpawnReq(context.Background(), SpawnRequest{
 		Task: "x", Model: "claude-sonnet-4-5", Provider: "anthropic",
+		Reasoning: "high", Subagent: "reviewer",
 	})
 	if err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	if a.Model != "claude-sonnet-4-5" || a.Provider != "anthropic" {
-		t.Fatalf("agent fields = (%q,%q); want (claude-sonnet-4-5, anthropic)", a.Model, a.Provider)
+	if a.Model != "claude-sonnet-4-5" || a.Provider != "anthropic" || a.Reasoning != "high" || a.Subagent != "reviewer" {
+		t.Fatalf("agent fields = (%q,%q,%q,%q); want model/provider/reasoning/profile", a.Model, a.Provider, a.Reasoning, a.Subagent)
 	}
 	snap := a.Snapshot()
-	if snap.Model != "claude-sonnet-4-5" || snap.Provider != "anthropic" {
-		t.Fatalf("snapshot = (%q,%q); model fields not surfaced", snap.Model, snap.Provider)
+	if snap.Model != "claude-sonnet-4-5" || snap.Provider != "anthropic" || snap.Reasoning != "high" || snap.Subagent != "reviewer" {
+		t.Fatalf("snapshot = (%q,%q,%q,%q); child fields not surfaced", snap.Model, snap.Provider, snap.Reasoning, snap.Subagent)
 	}
 
 	// Stop so we can read meta.json without racing the run loop.
@@ -564,8 +565,8 @@ func TestSpawnReqPersistsModel(t *testing.T) {
 	if err := json.Unmarshal(metaBytes, &got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Model != "claude-sonnet-4-5" || got.Provider != "anthropic" {
-		t.Errorf("meta = (%q,%q); want model + provider persisted", got.Model, got.Provider)
+	if got.Model != "claude-sonnet-4-5" || got.Provider != "anthropic" || got.Reasoning != "high" || got.Subagent != "reviewer" {
+		t.Errorf("meta = (%q,%q,%q,%q); want model/provider/reasoning/profile persisted", got.Model, got.Provider, got.Reasoning, got.Subagent)
 	}
 
 	// Reload in a fresh Swarm and confirm the detached agent still
@@ -579,8 +580,8 @@ func TestSpawnReqPersistsModel(t *testing.T) {
 	if re == nil {
 		t.Fatal("reloaded agent missing")
 	}
-	if re.Model != "claude-sonnet-4-5" || re.Provider != "anthropic" {
-		t.Errorf("reloaded fields = (%q,%q); want preserved", re.Model, re.Provider)
+	if re.Model != "claude-sonnet-4-5" || re.Provider != "anthropic" || re.Reasoning != "high" || re.Subagent != "reviewer" {
+		t.Errorf("reloaded fields = (%q,%q,%q,%q); want preserved", re.Model, re.Provider, re.Reasoning, re.Subagent)
 	}
 }
 

--- a/packages/agent/swarm/persist_test.go
+++ b/packages/agent/swarm/persist_test.go
@@ -536,6 +536,7 @@ func TestSpawnReqPersistsModel(t *testing.T) {
 			return RunnerFunc(func(ctx context.Context, _ Sink) error { <-ctx.Done(); return ctx.Err() })
 		},
 	})
+	f.SetActiveSession("host-session")
 	a, err := f.SpawnReq(context.Background(), SpawnRequest{
 		Task: "x", Model: "claude-sonnet-4-5", Provider: "anthropic",
 		Reasoning: "high", Subagent: "reviewer",
@@ -543,8 +544,8 @@ func TestSpawnReqPersistsModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	if a.Model != "claude-sonnet-4-5" || a.Provider != "anthropic" || a.Reasoning != "high" || a.Subagent != "reviewer" {
-		t.Fatalf("agent fields = (%q,%q,%q,%q); want model/provider/reasoning/profile", a.Model, a.Provider, a.Reasoning, a.Subagent)
+	if a.Model != "claude-sonnet-4-5" || a.Provider != "anthropic" || a.Reasoning != "high" || a.Subagent != "reviewer" || a.SessionID != "host-session" {
+		t.Fatalf("agent fields = (%q,%q,%q,%q,%q); want model/provider/reasoning/profile/session", a.Model, a.Provider, a.Reasoning, a.Subagent, a.SessionID)
 	}
 	snap := a.Snapshot()
 	if snap.Model != "claude-sonnet-4-5" || snap.Provider != "anthropic" || snap.Reasoning != "high" || snap.Subagent != "reviewer" {
@@ -565,14 +566,19 @@ func TestSpawnReqPersistsModel(t *testing.T) {
 	if err := json.Unmarshal(metaBytes, &got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Model != "claude-sonnet-4-5" || got.Provider != "anthropic" || got.Reasoning != "high" || got.Subagent != "reviewer" {
-		t.Errorf("meta = (%q,%q,%q,%q); want model/provider/reasoning/profile persisted", got.Model, got.Provider, got.Reasoning, got.Subagent)
+	if got.Model != "claude-sonnet-4-5" || got.Provider != "anthropic" || got.Reasoning != "high" || got.Subagent != "reviewer" || got.SessionID != "host-session" {
+		t.Errorf("meta = (%q,%q,%q,%q,%q); want model/provider/reasoning/profile/session persisted", got.Model, got.Provider, got.Reasoning, got.Subagent, got.SessionID)
 	}
 
 	// Reload in a fresh Swarm and confirm the detached agent still
 	// carries the model/provider so Resume can route the child
 	// subprocess back to the same model.
-	g := New(Config{Root: root, RepoRoot: root})
+	g := New(Config{
+		Root: root, RepoRoot: root,
+		NewRunner: func(a *Agent) Runner {
+			return RunnerFunc(func(ctx context.Context, _ Sink) error { <-ctx.Done(); return ctx.Err() })
+		},
+	})
 	if loaded, errs := g.Reload(); loaded != 1 || len(errs) > 0 {
 		t.Fatalf("reload loaded=%d errs=%v", loaded, errs)
 	}
@@ -580,9 +586,21 @@ func TestSpawnReqPersistsModel(t *testing.T) {
 	if re == nil {
 		t.Fatal("reloaded agent missing")
 	}
-	if re.Model != "claude-sonnet-4-5" || re.Provider != "anthropic" || re.Reasoning != "high" || re.Subagent != "reviewer" {
-		t.Errorf("reloaded fields = (%q,%q,%q,%q); want preserved", re.Model, re.Provider, re.Reasoning, re.Subagent)
+	if re.Model != "claude-sonnet-4-5" || re.Provider != "anthropic" || re.Reasoning != "high" || re.Subagent != "reviewer" || re.SessionID != "host-session" {
+		t.Errorf("reloaded fields = (%q,%q,%q,%q,%q); want preserved", re.Model, re.Provider, re.Reasoning, re.Subagent, re.SessionID)
 	}
+
+	resumed, err := g.Resume(context.Background(), re.ID)
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if resumed.Reasoning != "high" || resumed.Subagent != "reviewer" || resumed.SessionID != "host-session" {
+		t.Errorf("resumed fields = (%q,%q,%q); want reasoning/profile/session preserved", resumed.Reasoning, resumed.Subagent, resumed.SessionID)
+	}
+	if err := g.Stop(resumed.ID); err != nil {
+		t.Fatalf("stop resumed agent: %v", err)
+	}
+	resumed.Wait()
 }
 
 // TestSwarmAgentArgsIncludesModelFlags pins the argv contract that

--- a/packages/agent/swarm/runner.go
+++ b/packages/agent/swarm/runner.go
@@ -54,11 +54,10 @@ type execRunner struct {
 	SessionPath string
 }
 
-// swarmAgentArgsOpts captures every dynamic input to swarmAgentArgs
-// so future per-agent overrides (e.g. tools, reasoning) can be added
-// without churning the signature. The fields map 1:1 onto child CLI
-// flags; empty values omit the flag entirely and let the child
-// resolve a default the same way a normal `zot` invocation does.
+// swarmAgentArgsOpts captures every dynamic input to swarmAgentArgs.
+// The fields map 1:1 onto child CLI flags; empty values omit the flag
+// entirely and let the child resolve a default the same way a normal
+// `zot` invocation does.
 type swarmAgentArgsOpts struct {
 	Exe         string
 	Dir         string
@@ -67,6 +66,8 @@ type swarmAgentArgsOpts struct {
 	Task        string
 	Model       string
 	Provider    string
+	Reasoning   string
+	Subagent    string
 }
 
 // defaultChildArgs builds the argv execRunner uses when its Command
@@ -96,6 +97,8 @@ func defaultChildArgs(exe string, a *Agent, sessionPath, inboxPath string) []str
 		Task:        task,
 		Model:       a.Model,
 		Provider:    a.Provider,
+		Reasoning:   a.Reasoning,
+		Subagent:    a.Subagent,
 	})
 }
 
@@ -114,6 +117,12 @@ func swarmAgentArgs(opts swarmAgentArgsOpts) []string {
 	}
 	if opts.Provider != "" {
 		args = append(args, "--provider", opts.Provider)
+	}
+	if opts.Reasoning != "" {
+		args = append(args, "--reasoning", opts.Reasoning)
+	}
+	if opts.Subagent != "" {
+		args = append(args, "--subagent", opts.Subagent)
 	}
 	if opts.Task != "" {
 		// First task is positional so the child treats it as the

--- a/packages/agent/swarm/runner_test.go
+++ b/packages/agent/swarm/runner_test.go
@@ -171,6 +171,11 @@ func TestSwarmAgentArgsEmptyTaskOmitsPositional(t *testing.T) {
 	if a := args[len(args)-1]; strings.HasPrefix(a, "--") {
 		t.Fatalf("argv ends on a flag with no value: %v", args)
 	}
+	for _, flag := range []string{"--reasoning", "--subagent"} {
+		if indexOf(args, flag) >= 0 {
+			t.Fatalf("empty child options should omit %s: %v", flag, args)
+		}
+	}
 }
 
 // TestDefaultChildArgsSpawnIncludesTask pins the spawn shape: a

--- a/packages/agent/swarm/runner_test.go
+++ b/packages/agent/swarm/runner_test.go
@@ -113,6 +113,8 @@ func TestSwarmAgentArgs(t *testing.T) {
 		SessionPath: "/tmp/state/session.json",
 		InboxPath:   "/tmp/state/in.sock",
 		Task:        "do the thing",
+		Reasoning:   "high",
+		Subagent:    "reviewer",
 	})
 	if len(args) < 7 {
 		t.Fatalf("argv unexpectedly short: %v", args)
@@ -130,6 +132,8 @@ func TestSwarmAgentArgs(t *testing.T) {
 		"--swarm-agent": "/tmp/state/in.sock",
 		"--session":     "/tmp/state/session.json",
 		"--cwd":         "/tmp/worktree",
+		"--reasoning":   "high",
+		"--subagent":    "reviewer",
 	}
 	for flag, value := range mustHave {
 		i := indexOf(args, flag)

--- a/packages/agent/swarm/swarm.go
+++ b/packages/agent/swarm/swarm.go
@@ -148,6 +148,14 @@ func (f *Swarm) SetRepoRoot(root string) {
 	f.cfg.RepoRoot = root
 }
 
+// RepoRoot returns the working directory used by subsequently spawned
+// agents.
+func (f *Swarm) RepoRoot() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cfg.RepoRoot
+}
+
 // SetActiveSession scopes the dashboard view (and Spawn stamping)
 // to a particular host zot session id. Pass empty to clear the
 // scope and revert to "show every agent" (the original behaviour).

--- a/packages/agent/swarm/swarm.go
+++ b/packages/agent/swarm/swarm.go
@@ -177,11 +177,16 @@ func (f *Swarm) agentStateDir(id string) string {
 // SpawnRequest configures a Spawn. Only Task is required; the rest
 // are optional. Model + Provider, when set, get baked into the
 // child argv as --model / --provider so the agent runs against the
-// chosen model regardless of the parent's current selection.
+// chosen model regardless of the parent's current selection. A named
+// Subagent is passed to the child as --subagent, where it resolves the
+// markdown profile and applies its instructions. Reasoning is passed
+// as --reasoning when set.
 type SpawnRequest struct {
-	Task     string
-	Model    string // optional override; child resolves default if empty
-	Provider string // optional override; usually paired with Model
+	Task      string
+	Model     string // optional override; child resolves default if empty
+	Provider  string // optional override; usually paired with Model
+	Reasoning string // optional reasoning/thinking level override
+	Subagent  string // optional named markdown profile
 }
 
 // Spawn creates a new Agent for the given task, allocates its
@@ -238,6 +243,8 @@ func (f *Swarm) SpawnReq(ctx context.Context, req SpawnRequest) (*Agent, error) 
 		Started:      f.cfg.Now(),
 		Model:        strings.TrimSpace(req.Model),
 		Provider:     strings.TrimSpace(req.Provider),
+		Reasoning:    strings.TrimSpace(req.Reasoning),
+		Subagent:     strings.TrimSpace(req.Subagent),
 		SessionID:    sessionID,
 		InboxPath:    inboxPath,
 		EventLogPath: logPath,
@@ -444,12 +451,15 @@ type AgentSnapshot struct {
 	Lines         []string // full transcript (already capped by Agent.appendTranscript)
 	LastAssistant string   // complete final assistant message, without role formatting
 
-	// Model and Provider expose the per-agent overrides set at
-	// Spawn time (empty when the agent inherits the child's default
-	// resolution). The dashboard surfaces these so the user can
-	// confirm which model an agent is running against.
-	Model    string
-	Provider string
+	// Model, Provider, and Reasoning expose the per-agent overrides set
+	// at Spawn time (empty when the agent inherits the child's default
+	// resolution). Subagent is the selected named markdown profile.
+	// The dashboard surfaces these so the user can confirm the child
+	// configuration.
+	Model     string
+	Provider  string
+	Reasoning string
+	Subagent  string
 
 	// Paths to the agent's durable state. Surface them in the
 	// snapshot so the dashboard / /swarm open can read events.jsonl
@@ -479,6 +489,8 @@ func (a *Agent) Snapshot() AgentSnapshot {
 		LastAssistant: a.lastAssistant,
 		Model:         a.Model,
 		Provider:      a.Provider,
+		Reasoning:     a.Reasoning,
+		Subagent:      a.Subagent,
 		InboxPath:     a.InboxPath,
 		EventLogPath:  a.EventLogPath,
 		SessionPath:   a.SessionPath,

--- a/packages/agent/swarm/swarm.go
+++ b/packages/agent/swarm/swarm.go
@@ -139,6 +139,15 @@ func New(cfg Config) *Swarm {
 	}
 }
 
+// SetRepoRoot updates the shared working directory for subsequently
+// spawned agents. Existing agents keep the directory they were started
+// with; callers use this when the host session changes cwd.
+func (f *Swarm) SetRepoRoot(root string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cfg.RepoRoot = root
+}
+
 // SetActiveSession scopes the dashboard view (and Spawn stamping)
 // to a particular host zot session id. Pass empty to clear the
 // scope and revert to "show every agent" (the original behaviour).
@@ -213,7 +222,13 @@ func (f *Swarm) SpawnReq(ctx context.Context, req SpawnRequest) (*Agent, error) 
 		return nil, errors.New("swarm: empty task")
 	}
 	id := newAgentID(task, f.cfg.Now())
+
+	// Snapshot the shared cwd together with the active session so a
+	// concurrent /cd cannot race a spawn or produce a mixed snapshot.
+	f.mu.Lock()
 	dir := f.cfg.RepoRoot
+	sessionID := f.activeSession
+	f.mu.Unlock()
 
 	stateDir := f.agentStateDir(id)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
@@ -228,13 +243,6 @@ func (f *Swarm) SpawnReq(ctx context.Context, req SpawnRequest) (*Agent, error) 
 	if err != nil {
 		return nil, fmt.Errorf("swarm inbox path: %w", err)
 	}
-
-	// Snapshot activeSession under the lock; we use it twice (struct
-	// init below + persistence). Reading it without the lock would
-	// race a concurrent SetActiveSession call.
-	f.mu.Lock()
-	sessionID := f.activeSession
-	f.mu.Unlock()
 
 	a := &Agent{
 		ID:           id,

--- a/packages/agent/swarm/swarm_test.go
+++ b/packages/agent/swarm/swarm_test.go
@@ -78,6 +78,22 @@ func TestSpawnAgentSharesRepoRoot(t *testing.T) {
 	}
 }
 
+func TestSetRepoRootAffectsSubsequentSpawns(t *testing.T) {
+	f := newTestSwarm(t, func(a *Agent) Runner {
+		return RunnerFunc(func(ctx context.Context, sink Sink) error { return nil })
+	})
+	want := t.TempDir()
+	f.SetRepoRoot(want)
+	a, err := f.Spawn(context.Background(), "use new root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.Wait()
+	if a.Dir != want {
+		t.Fatalf("Dir = %q; want updated RepoRoot %q", a.Dir, want)
+	}
+}
+
 func TestSpawnEmptyTaskFails(t *testing.T) {
 	f := newTestSwarm(t, func(a *Agent) Runner {
 		return RunnerFunc(func(ctx context.Context, sink Sink) error { return nil })

--- a/packages/agent/tools/swarm_spawn.go
+++ b/packages/agent/tools/swarm_spawn.go
@@ -101,10 +101,10 @@ func (t *SwarmSpawnTool) Schema() json.RawMessage { return json.RawMessage(swarm
 
 func (t *SwarmSpawnTool) Execute(ctx context.Context, raw json.RawMessage, progress func(string)) (core.ToolResult, error) {
 	if t.Swarm == nil {
-		return toolErr("swarm_spawn: swarm supervisor not available in this mode"), nil
+		return protocolToolError("swarm_spawn: swarm supervisor not available in this mode")
 	}
 	if t.Enabled == nil || !t.Enabled() {
-		return toolErr("swarm_spawn: auto-swarm is disabled. Ask the user to enable it from /settings before delegating sub-tasks."), nil
+		return protocolToolError("swarm_spawn: auto-swarm is disabled. Ask the user to enable it from /settings before delegating sub-tasks.")
 	}
 	var a swarmSpawnArgs
 	if err := json.Unmarshal(raw, &a); err != nil {
@@ -112,22 +112,22 @@ func (t *SwarmSpawnTool) Execute(ctx context.Context, raw json.RawMessage, progr
 	}
 	task := strings.TrimSpace(a.Task)
 	if task == "" {
-		return toolErr("swarm_spawn: task is required"), nil
+		return protocolToolError("swarm_spawn: task is required")
 	}
 
 	agentName := strings.TrimSpace(a.Agent)
 	var profile *subagents.Profile
 	if agentName != "" {
 		if t.ResolveSubagent == nil {
-			return toolErr("swarm_spawn: named subagent profiles are unavailable"), nil
+			return protocolToolError("swarm_spawn: named subagent profiles are unavailable")
 		}
 		var err error
 		profile, err = t.ResolveSubagent(agentName)
 		if err != nil {
-			return toolErr("swarm_spawn: " + err.Error()), nil
+			return protocolToolError("swarm_spawn: " + err.Error())
 		}
 		if profile == nil {
-			return toolErr("swarm_spawn: unknown subagent profile " + agentName), nil
+			return protocolToolError("swarm_spawn: unknown subagent profile " + agentName)
 		}
 		agentName = profile.Name
 	}
@@ -135,7 +135,7 @@ func (t *SwarmSpawnTool) Execute(ctx context.Context, raw json.RawMessage, progr
 	model := strings.TrimSpace(a.Model)
 	providerID := strings.TrimSpace(a.Provider)
 	if (model == "") != (providerID == "") {
-		return toolErr("swarm_spawn: omit both model/provider to inherit the host or profile, or provide both explicitly"), nil
+		return protocolToolError("swarm_spawn: omit both model/provider to inherit the host or profile, or provide both explicitly")
 	}
 	if model == "" && providerID == "" && profile != nil {
 		// A fully-qualified profile model is useful metadata for the
@@ -158,18 +158,18 @@ func (t *SwarmSpawnTool) Execute(ctx context.Context, raw json.RawMessage, progr
 
 	reasoning, err := reasoningOverride(a.Reasoning, a.Thinking)
 	if err != nil {
-		return toolErr("swarm_spawn: " + err.Error()), nil
+		return protocolToolError("swarm_spawn: " + err.Error())
 	}
 	if reasoning == "" && profile != nil && strings.TrimSpace(profile.Thinking) != "" {
 		reasoning, err = reasoningOverride(profile.Thinking, "")
 		if err != nil {
-			return toolErr("swarm_spawn: profile " + profile.Name + ": " + err.Error()), nil
+			return protocolToolError("swarm_spawn: profile " + profile.Name + ": " + err.Error())
 		}
 	}
 	if reasoning == "" && t.DefaultReasoning != nil {
 		reasoning, err = reasoningOverride(t.DefaultReasoning(), "")
 		if err != nil {
-			return toolErr("swarm_spawn: host " + err.Error()), nil
+			return protocolToolError("swarm_spawn: host " + err.Error())
 		}
 	}
 
@@ -239,6 +239,13 @@ func reasoningOverride(reasoning, thinking string) (string, error) {
 	default:
 		return "", fmt.Errorf("reasoning must be off|minimum|low|medium|high|xhigh|max")
 	}
+}
+
+// protocolToolError keeps model-visible validation failures in the
+// ToolResult channel rather than treating them as host execution errors.
+func protocolToolError(msg string) (core.ToolResult, error) {
+	//nolint:nilerr // ToolResult.IsError is the established tool protocol.
+	return toolErr(msg), nil
 }
 
 func toolErr(msg string) core.ToolResult {

--- a/packages/agent/tools/swarm_spawn.go
+++ b/packages/agent/tools/swarm_spawn.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/patriceckhart/zot/packages/agent/subagents"
 	"github.com/patriceckhart/zot/packages/agent/swarm"
 	"github.com/patriceckhart/zot/packages/core"
 	"github.com/patriceckhart/zot/packages/provider"
@@ -33,22 +34,30 @@ type SwarmSpawnTool struct {
 
 	// DefaultModel and DefaultProvider return the host agent's resolved
 	// model and provider. They are used when the tool call omits both
-	// fields, so auto-swarm follows the same auth route as the user sees
-	// in the parent session.
-	DefaultModel    func() string
-	DefaultProvider func() string
+	// fields and does not select a named profile, so auto-swarm follows
+	// the same auth route as the user sees in the parent session.
+	DefaultModel     func() string
+	DefaultProvider  func() string
+	DefaultReasoning func() string
+
+	// ResolveSubagent validates and resolves a named markdown profile.
+	// The child receives only the name and loads the profile itself.
+	ResolveSubagent func(name string) (*subagents.Profile, error)
 
 	// OnSpawned, if set, is called after every successful spawn with
 	// the new agent + the task it was started with. Used by the
 	// interactive host to track agents and surface a summary back
-	// in the main chat once they all finish.
+	// in chat when all sub-agents finish.
 	OnSpawned func(agent *swarm.Agent, task string)
 }
 
 type swarmSpawnArgs struct {
-	Task     string `json:"task"`
-	Model    string `json:"model,omitempty"`
-	Provider string `json:"provider,omitempty"`
+	Task      string `json:"task"`
+	Agent     string `json:"agent,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Provider  string `json:"provider,omitempty"`
+	Reasoning string `json:"reasoning,omitempty"`
+	Thinking  string `json:"thinking,omitempty"`
 }
 
 const swarmSpawnSchema = `{
@@ -56,15 +65,29 @@ const swarmSpawnSchema = `{
   "properties": {
     "task": {
       "type": "string",
-      "description": "The full task description for the sub-agent. Be specific: the sub-agent has the same tools (read/write/edit/bash) and shares this working directory, but starts with NO context from this conversation."
+      "description": "The full task description for the sub-agent. Be specific: the sub-agent has the same read/write/edit/bash tools as the main agent and shares this working directory, but starts with NO context from this conversation."
+    },
+    "agent": {
+      "type": "string",
+      "description": "Optional named markdown profile from [subagents_list]. The child applies that profile's system prompt, model, thinking level, and tool limits. Omit for a generic child."
     },
     "model": {
       "type": "string",
-      "description": "Optional model id to pin the sub-agent to. Normally omit both model and provider so the sub-agent inherits the host session's resolved provider/model/auth route. Do not infer provider from model name. If you override this, also provide provider."
+      "description": "Optional model id to pin the sub-agent to. Normally omit both model and provider so the sub-agent inherits the host session's resolved provider/model/auth route, or omit them when using an agent profile. Do not infer provider from model name. If you override this, also provide provider."
     },
     "provider": {
       "type": "string",
       "description": "Optional provider id. Normally omit both model and provider so the sub-agent inherits the host session. If you override this, also provide model. Note: openai means public OpenAI API-key auth; openai-codex means ChatGPT/Codex subscription auth."
+    },
+    "reasoning": {
+      "type": "string",
+      "enum": ["off", "minimum", "low", "medium", "high", "xhigh", "max"],
+      "description": "Optional reasoning/thinking level for the child. Overrides the selected profile's thinking level when provided."
+    },
+    "thinking": {
+      "type": "string",
+      "enum": ["off", "minimum", "low", "medium", "high", "xhigh", "max"],
+      "description": "Alias for reasoning, accepted for compatibility with common agent profile terminology. Prefer reasoning when both are available."
     }
   },
   "required": ["task"]
@@ -72,7 +95,7 @@ const swarmSpawnSchema = `{
 
 func (t *SwarmSpawnTool) Name() string { return "swarm_spawn" }
 func (t *SwarmSpawnTool) Description() string {
-	return "Spawn a background sub-agent to work on a parallel sub-task. Returns the sub-agent id immediately; the sub-agent keeps running while this conversation continues. Useful for splitting independent work (write tests while implementing a feature, refactor module A while drafting module B). The sub-agent shares this working directory and has the same tools."
+	return "Spawn a background sub-agent to work on a parallel sub-task. Optionally select a named markdown profile with agent and set its model/provider/reasoning. Returns the sub-agent id immediately; the sub-agent keeps running while this conversation continues. The sub-agent shares this working directory."
 }
 func (t *SwarmSpawnTool) Schema() json.RawMessage { return json.RawMessage(swarmSpawnSchema) }
 
@@ -92,12 +115,39 @@ func (t *SwarmSpawnTool) Execute(ctx context.Context, raw json.RawMessage, progr
 		return toolErr("swarm_spawn: task is required"), nil
 	}
 
+	agentName := strings.TrimSpace(a.Agent)
+	var profile *subagents.Profile
+	if agentName != "" {
+		if t.ResolveSubagent == nil {
+			return toolErr("swarm_spawn: named subagent profiles are unavailable"), nil
+		}
+		var err error
+		profile, err = t.ResolveSubagent(agentName)
+		if err != nil {
+			return toolErr("swarm_spawn: " + err.Error()), nil
+		}
+		if profile == nil {
+			return toolErr("swarm_spawn: unknown subagent profile " + agentName), nil
+		}
+		agentName = profile.Name
+	}
+
 	model := strings.TrimSpace(a.Model)
 	providerID := strings.TrimSpace(a.Provider)
 	if (model == "") != (providerID == "") {
-		return toolErr("swarm_spawn: omit both model/provider to inherit the host, or provide both explicitly"), nil
+		return toolErr("swarm_spawn: omit both model/provider to inherit the host or profile, or provide both explicitly"), nil
 	}
-	if model == "" && providerID == "" {
+	if model == "" && providerID == "" && profile != nil {
+		// A fully-qualified profile model is useful metadata for the
+		// supervisor and also lets it inherit the right credential route.
+		// Bare profile model ids remain child-resolved so the configured
+		// provider is preserved.
+		profileProvider, profileModel := profile.ModelSelection()
+		if profileProvider != "" && profileModel != "" {
+			providerID, model = profileProvider, profileModel
+		}
+	}
+	if model == "" && providerID == "" && profile == nil {
 		if t.DefaultModel != nil {
 			model = strings.TrimSpace(t.DefaultModel())
 		}
@@ -106,10 +156,29 @@ func (t *SwarmSpawnTool) Execute(ctx context.Context, raw json.RawMessage, progr
 		}
 	}
 
+	reasoning, err := reasoningOverride(a.Reasoning, a.Thinking)
+	if err != nil {
+		return toolErr("swarm_spawn: " + err.Error()), nil
+	}
+	if reasoning == "" && profile != nil && strings.TrimSpace(profile.Thinking) != "" {
+		reasoning, err = reasoningOverride(profile.Thinking, "")
+		if err != nil {
+			return toolErr("swarm_spawn: profile " + profile.Name + ": " + err.Error()), nil
+		}
+	}
+	if reasoning == "" && t.DefaultReasoning != nil {
+		reasoning, err = reasoningOverride(t.DefaultReasoning(), "")
+		if err != nil {
+			return toolErr("swarm_spawn: host " + err.Error()), nil
+		}
+	}
+
 	agent, err := t.Swarm.SpawnReq(ctx, swarm.SpawnRequest{
-		Task:     task,
-		Model:    model,
-		Provider: providerID,
+		Task:      task,
+		Model:     model,
+		Provider:  providerID,
+		Reasoning: reasoning,
+		Subagent:  agentName,
 	})
 	if err != nil {
 		return core.ToolResult{}, fmt.Errorf("swarm_spawn: %w", err)
@@ -121,23 +190,55 @@ func (t *SwarmSpawnTool) Execute(ctx context.Context, raw json.RawMessage, progr
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "spawned sub-agent %s\n", agent.ID)
 	fmt.Fprintf(&sb, "task: %s\n", truncateTask(task, 200))
+	if agentName != "" {
+		fmt.Fprintf(&sb, "agent: %s\n", agentName)
+	}
 	if model != "" {
 		fmt.Fprintf(&sb, "model: %s\n", model)
 	}
 	if providerID != "" {
 		fmt.Fprintf(&sb, "provider: %s\n", providerID)
 	}
+	if reasoning != "" {
+		fmt.Fprintf(&sb, "reasoning: %s\n", reasoning)
+	}
 	sb.WriteString("\nThe sub-agent is running in the background. Use /swarm in the TUI to monitor it. ")
 	sb.WriteString("This conversation continues immediately; do not wait for the sub-agent to finish before working on the next thing.")
 	return core.ToolResult{
 		Content: []provider.Content{provider.TextBlock{Text: sb.String()}},
 		Details: map[string]any{
-			"agent_id": agent.ID,
-			"task":     task,
-			"model":    model,
-			"provider": providerID,
+			"agent_id":  agent.ID,
+			"task":      task,
+			"agent":     agentName,
+			"model":     model,
+			"provider":  providerID,
+			"reasoning": reasoning,
 		},
 	}, nil
+}
+
+func reasoningOverride(reasoning, thinking string) (string, error) {
+	reasoning = strings.TrimSpace(reasoning)
+	thinking = strings.TrimSpace(thinking)
+	if reasoning != "" && thinking != "" && provider.NormalizeReasoning(reasoning) != provider.NormalizeReasoning(thinking) {
+		return "", fmt.Errorf("reasoning and thinking disagree; provide only one")
+	}
+	value := reasoning
+	if value == "" {
+		value = thinking
+	}
+	if value == "" {
+		return "", nil
+	}
+	normalized := provider.NormalizeReasoning(value)
+	switch normalized {
+	case "":
+		return "off", nil
+	case "minimum", "low", "medium", "high", "xhigh", "max":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("reasoning must be off|minimum|low|medium|high|xhigh|max")
+	}
 }
 
 func toolErr(msg string) core.ToolResult {

--- a/packages/agent/tools/swarm_spawn_test.go
+++ b/packages/agent/tools/swarm_spawn_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/patriceckhart/zot/packages/agent/subagents"
 	"github.com/patriceckhart/zot/packages/agent/swarm"
 	"github.com/patriceckhart/zot/packages/provider"
 )
@@ -29,10 +30,11 @@ func newTestSwarm(t *testing.T) *swarm.Swarm {
 
 func TestSwarmSpawnInheritsHostModelAndProviderWhenOmitted(t *testing.T) {
 	tool := &SwarmSpawnTool{
-		Swarm:           newTestSwarm(t),
-		Enabled:         func() bool { return true },
-		DefaultModel:    func() string { return "gpt-5" },
-		DefaultProvider: func() string { return "openai-codex" },
+		Swarm:            newTestSwarm(t),
+		Enabled:          func() bool { return true },
+		DefaultModel:     func() string { return "gpt-5" },
+		DefaultProvider:  func() string { return "openai-codex" },
+		DefaultReasoning: func() string { return "medium" },
 	}
 
 	res, err := tool.Execute(context.Background(), json.RawMessage(`{"task":"research docs"}`), nil)
@@ -52,8 +54,11 @@ func TestSwarmSpawnInheritsHostModelAndProviderWhenOmitted(t *testing.T) {
 	if got := details["provider"]; got != "openai-codex" {
 		t.Fatalf("provider detail = %v, want openai-codex", got)
 	}
+	if got := details["reasoning"]; got != "medium" {
+		t.Fatalf("reasoning detail = %v, want medium", got)
+	}
 	text := textResult(res.Content)
-	if !strings.Contains(text, "model: gpt-5") || !strings.Contains(text, "provider: openai-codex") {
+	if !strings.Contains(text, "model: gpt-5") || !strings.Contains(text, "provider: openai-codex") || !strings.Contains(text, "reasoning: medium") {
 		t.Fatalf("result text missing inherited model/provider:\n%s", text)
 	}
 
@@ -61,8 +66,63 @@ func TestSwarmSpawnInheritsHostModelAndProviderWhenOmitted(t *testing.T) {
 	if len(agents) != 1 {
 		t.Fatalf("spawned agents = %d, want 1", len(agents))
 	}
-	if agents[0].Model != "gpt-5" || agents[0].Provider != "openai-codex" {
-		t.Fatalf("agent model/provider = %q/%q, want gpt-5/openai-codex", agents[0].Model, agents[0].Provider)
+	if agents[0].Model != "gpt-5" || agents[0].Provider != "openai-codex" || agents[0].Reasoning != "medium" {
+		t.Fatalf("agent model/provider/reasoning = %q/%q/%q, want gpt-5/openai-codex/medium", agents[0].Model, agents[0].Provider, agents[0].Reasoning)
+	}
+}
+
+func TestSwarmSpawnSelectsProfileAndReasoning(t *testing.T) {
+	tool := &SwarmSpawnTool{
+		Swarm:   newTestSwarm(t),
+		Enabled: func() bool { return true },
+		ResolveSubagent: func(name string) (*subagents.Profile, error) {
+			if name != "reviewer" {
+				return nil, nil
+			}
+			return &subagents.Profile{
+				Name:     "reviewer",
+				Model:    "openai-codex/gpt-5.6-luna",
+				Thinking: "low",
+			}, nil
+		},
+	}
+
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"task":"review auth","agent":"reviewer","reasoning":"high"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textResult(res.Content))
+	}
+	text := textResult(res.Content)
+	for _, want := range []string{"agent: reviewer", "model: gpt-5.6-luna", "provider: openai-codex", "reasoning: high"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("result text missing %q:\n%s", want, text)
+		}
+	}
+	agents := tool.Swarm.List()
+	if len(agents) != 1 || agents[0].Subagent != "reviewer" || agents[0].Reasoning != "high" {
+		t.Fatalf("agent profile/reasoning = %#v", agents)
+	}
+}
+
+func TestSwarmSpawnRejectsUnknownProfile(t *testing.T) {
+	tool := &SwarmSpawnTool{
+		Swarm:   newTestSwarm(t),
+		Enabled: func() bool { return true },
+		ResolveSubagent: func(string) (*subagents.Profile, error) {
+			return nil, nil
+		},
+	}
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"task":"review auth","agent":"missing"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(textResult(res.Content), "unknown subagent profile") {
+		t.Fatalf("result = %#v, want unknown profile error", res)
+	}
+	if got := len(tool.Swarm.List()); got != 0 {
+		t.Fatalf("spawned agents = %d, want 0", got)
 	}
 }
 

--- a/packages/agent/tools/swarm_spawn_test.go
+++ b/packages/agent/tools/swarm_spawn_test.go
@@ -104,6 +104,38 @@ func TestSwarmSpawnSelectsProfileAndReasoning(t *testing.T) {
 	if len(agents) != 1 || agents[0].Subagent != "reviewer" || agents[0].Reasoning != "high" {
 		t.Fatalf("agent profile/reasoning = %#v", agents)
 	}
+	if agents[0].Model != "gpt-5.6-luna" || agents[0].Provider != "openai-codex" {
+		t.Fatalf("agent model/provider = %q/%q, want gpt-5.6-luna/openai-codex", agents[0].Model, agents[0].Provider)
+	}
+}
+
+func TestSwarmSpawnUsesProfileReasoningWhenOmitted(t *testing.T) {
+	tool := &SwarmSpawnTool{
+		Swarm:   newTestSwarm(t),
+		Enabled: func() bool { return true },
+		ResolveSubagent: func(name string) (*subagents.Profile, error) {
+			if name != "reviewer" {
+				return nil, nil
+			}
+			return &subagents.Profile{
+				Name:     "reviewer",
+				Model:    "openai-codex/gpt-5.6-luna",
+				Thinking: "low",
+			}, nil
+		},
+	}
+
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{"task":"review auth","agent":"reviewer"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textResult(res.Content))
+	}
+	agents := tool.Swarm.List()
+	if len(agents) != 1 || agents[0].Reasoning != "low" {
+		t.Fatalf("agent reasoning = %#v, want low", agents)
+	}
 }
 
 func TestSwarmSpawnRejectsUnknownProfile(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add reusable Markdown/frontmatter subagent profiles from `~/.agents/agents`, with optional Pi-compatible discovery.
- Expose profile metadata to auto-swarm and support per-child profile, model, provider, and reasoning overrides.
- Persist profile/reasoning/session state across swarm reloads and resumes.
- Keep cwd changes transactional and preserve user-owned prompt text when toggling auto-swarm.

## Validation

- `make test`
- `go vet ./...`
- `git diff --check`
