### PR TITLE
Add Gondola provider

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -112,6 +112,7 @@ show instructions and should be configured with environment variables.
 | Together AI | `TOGETHER_API_KEY` | `together` |
 | Hugging Face | `HF_TOKEN` | `huggingface` |
 | OpenRouter | `OPENROUTER_API_KEY` | `openrouter` |
+| Gondola | `GONDOLA_API_KEY` | `gondola` |
 | Mistral | `MISTRAL_API_KEY` | `mistral` |
 | ZAI | `ZAI_API_KEY` | `zai` |
 | Xiaomi MiMo | `XIAOMI_API_KEY` | `xiaomi` |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -130,6 +130,9 @@ show instructions and should be configured with environment variables.
 | Cloudflare AI Gateway | `CLOUDFLARE_API_KEY` | `cloudflare-ai-gateway` |
 | Azure OpenAI Responses | `AZURE_OPENAI_API_KEY` | `azure-openai-responses` |
 
+When Gondola credentials are available, zot refreshes its public text-model
+catalog in the background and adds the discovered models to `/model`.
+
 Example:
 
 ```bash

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -183,6 +183,8 @@ func defaultModelForProvider(prov string) string {
 		return "moonshotai/Kimi-K2-Instruct"
 	case "openrouter":
 		return "anthropic/claude-sonnet-4.5"
+	case "gondola":
+		return "claude-opus-5"
 	case "mistral":
 		return "mistral-large-latest"
 	case "zai":
@@ -224,7 +226,7 @@ func defaultModelForProvider(prov string) string {
 var knownProviders = []string{
 	"anthropic", "openai", "openai-codex", "openai-responses", "kimi", "deepseek", "google", "ollama", provider.LlamaCPPProviderID,
 	"moonshotai", "moonshotai-cn",
-	"cerebras", "groq", "xai", "together", "huggingface", "openrouter",
+	"cerebras", "groq", "xai", "together", "huggingface", "openrouter", "gondola",
 	"mistral", "zai",
 	"xiaomi", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn", "xiaomi-token-plan-sgp",
 	"minimax", "minimax-cn",
@@ -831,6 +833,8 @@ func (r Resolved) NewClient() provider.Client {
 		return wrap(provider.NewHuggingFace(r.Credential, r.BaseURL))
 	case "openrouter":
 		return wrap(provider.NewOpenRouter(r.Credential, r.BaseURL))
+	case "gondola":
+		return wrap(provider.NewGondola(r.Credential, r.BaseURL))
 	case "zai":
 		return wrap(provider.NewZAI(r.Credential, r.BaseURL))
 	case "xiaomi":
@@ -1073,6 +1077,8 @@ func envVarName(provider string) string {
 		return "HF"
 	case "openrouter":
 		return "OPENROUTER"
+	case "gondola":
+		return "GONDOLA"
 	case "mistral":
 		return "MISTRAL"
 	case "zai":

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -184,7 +184,7 @@ func defaultModelForProvider(prov string) string {
 	case "openrouter":
 		return "anthropic/claude-sonnet-4.5"
 	case "gondola":
-		return "claude-opus-5"
+		return "kimi-k3"
 	case "mistral":
 		return "mistral-large-latest"
 	case "zai":

--- a/packages/agent/config.go
+++ b/packages/agent/config.go
@@ -415,6 +415,10 @@ func resolveCredentialFull(ctx context.Context, provider, explicit string, comma
 		if v := os.Getenv("OPENROUTER_API_KEY"); v != "" {
 			return v, "apikey", "", nil
 		}
+	case "gondola":
+		if v := os.Getenv("GONDOLA_API_KEY"); v != "" {
+			return v, "apikey", "", nil
+		}
 	case "mistral":
 		if v := os.Getenv("MISTRAL_API_KEY"); v != "" {
 			return v, "apikey", "", nil

--- a/packages/agent/modelsync.go
+++ b/packages/agent/modelsync.go
@@ -217,6 +217,13 @@ func refreshModels() {
 			all = append(all, live...)
 		}
 	}
+	if _, _, err := resolveCredentialForBackground(ctx, "gondola"); err == nil {
+		// Gondola's catalog is also public. Gate discovery on a credential so
+		// its text models only fill the picker for users of the provider.
+		if live, err := provider.DiscoverGondola(ctx, ""); err == nil {
+			all = append(all, live...)
+		}
+	}
 
 	if len(all) == 0 {
 		return

--- a/packages/provider/auth/auth_test.go
+++ b/packages/provider/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -18,6 +19,34 @@ func TestProbeAPIKeyAcceptsExtraProviderWithoutProbe(t *testing.T) {
 	if err := ProbeAPIKey(context.Background(), "my-company", "test-key"); err != nil {
 		t.Fatalf("ProbeAPIKey custom provider: %v", err)
 	}
+}
+
+func TestProbeGondolaAPIKeyUsesAuthenticatedBalanceEndpoint(t *testing.T) {
+	client := &http.Client{Transport: authRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != "https://api.gondola-ai.com/v1/balance" {
+			t.Fatalf("probe URL = %q", req.URL.String())
+		}
+		if got := req.Header.Get("authorization"); got != "Bearer gnd_test" {
+			t.Fatalf("authorization = %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"invalid key"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	err := probeAPIKey(context.Background(), "gondola", "gnd_test", client)
+	if err == nil || !strings.Contains(err.Error(), "rejected the key") {
+		t.Fatalf("probeAPIKey error = %v", err)
+	}
+}
+
+type authRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f authRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestStoreRoundTrip(t *testing.T) {

--- a/packages/provider/auth/probe.go
+++ b/packages/provider/auth/probe.go
@@ -99,6 +99,12 @@ func ProbeAPIKey(ctx context.Context, provider, key string) error {
 			return err
 		}
 		req.Header.Set("authorization", "Bearer "+key)
+	case "gondola":
+		req, err = http.NewRequestWithContext(ctx, "GET", "https://api.gondola-ai.com/v1/models", nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("authorization", "Bearer "+key)
 	case "huggingface":
 		req, err = http.NewRequestWithContext(ctx, "GET", "https://router.huggingface.co/v1/models", nil)
 		if err != nil {

--- a/packages/provider/auth/probe.go
+++ b/packages/provider/auth/probe.go
@@ -12,10 +12,13 @@ import (
 // ProbeAPIKey verifies that key is valid for provider by making a
 // lightweight authenticated request. Returns nil on success.
 func ProbeAPIKey(ctx context.Context, provider, key string) error {
+	return probeAPIKey(ctx, provider, key, &http.Client{Timeout: 15 * time.Second})
+}
+
+func probeAPIKey(ctx context.Context, provider, key string, c *http.Client) error {
 	if key == "" {
 		return fmt.Errorf("empty key")
 	}
-	c := &http.Client{Timeout: 15 * time.Second}
 	var req *http.Request
 	var err error
 
@@ -100,7 +103,7 @@ func ProbeAPIKey(ctx context.Context, provider, key string) error {
 		}
 		req.Header.Set("authorization", "Bearer "+key)
 	case "gondola":
-		req, err = http.NewRequestWithContext(ctx, "GET", "https://api.gondola-ai.com/v1/models", nil)
+		req, err = http.NewRequestWithContext(ctx, "GET", "https://api.gondola-ai.com/v1/balance", nil)
 		if err != nil {
 			return err
 		}

--- a/packages/provider/auth/server.go
+++ b/packages/provider/auth/server.go
@@ -138,7 +138,7 @@ func APIKeyProviders() []string {
 	return []string{
 		"anthropic", "openai", "kimi", "deepseek", "google", "llama.cpp",
 		"moonshotai", "moonshotai-cn", "groq", "cerebras", "xai", "together",
-		"huggingface", "openrouter", "mistral", "zai",
+		"huggingface", "openrouter", "gondola", "mistral", "zai",
 		"xiaomi", "xiaomi-token-plan-ams", "xiaomi-token-plan-cn", "xiaomi-token-plan-sgp",
 		"minimax", "minimax-cn", "fireworks", "vercel-ai-gateway",
 		"opencode", "opencode-go", "amazon-bedrock", "google-vertex", "azure-openai-responses",

--- a/packages/provider/discover.go
+++ b/packages/provider/discover.go
@@ -227,7 +227,10 @@ func looksLikeChatModel(id string) bool {
 	return false
 }
 
-const openrouterDefaultBaseURL = "https://openrouter.ai/api/v1"
+const (
+	openrouterDefaultBaseURL = "https://openrouter.ai/api/v1"
+	gondolaDefaultBaseURL    = "https://api.gondola-ai.com/v1"
+)
 
 // DiscoverOpenRouter lists models from OpenRouter's public /models
 // endpoint (no auth). Per-token USD prices are converted to USD per 1M
@@ -318,6 +321,76 @@ func openrouterSupportsReasoning(params []string) bool {
 		}
 	}
 	return false
+}
+
+// DiscoverGondola lists text models from Gondola's public catalog. Gondola
+// reports prices directly in USD per 1M tokens, matching Model's units.
+func DiscoverGondola(ctx context.Context, baseURL string) ([]Model, error) {
+	if baseURL == "" {
+		baseURL = gondolaDefaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gondola discover http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var page struct {
+		Data []struct {
+			ID                  string `json:"id"`
+			DisplayName         string `json:"display_name"`
+			Modality            string `json:"modality"`
+			Endpoint            string `json:"endpoint"`
+			ContextLength       int    `json:"context_length"`
+			MaxCompletionTokens int    `json:"max_completion_tokens"`
+			SupportsReasoning   bool   `json:"supports_reasoning"`
+			Pricing             struct {
+				Input      float64 `json:"input_usd_per_mtok"`
+				Output     float64 `json:"output_usd_per_mtok"`
+				CacheRead  float64 `json:"cached_input_usd_per_mtok"`
+				CacheWrite float64 `json:"cache_write_usd_per_mtok"`
+			} `json:"pricing"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("gondola discover parse: %w", err)
+	}
+	out := make([]Model, 0, len(page.Data))
+	for _, d := range page.Data {
+		if d.ID == "" || d.Modality != "text" || d.Endpoint != "/v1/chat/completions" {
+			continue
+		}
+		display := d.DisplayName
+		if display == "" {
+			display = d.ID
+		}
+		model := Model{ID: d.ID}
+		out = append(out, Model{
+			Provider:         "gondola",
+			ID:               d.ID,
+			DisplayName:      display,
+			ContextWindow:    d.ContextLength,
+			MaxOutput:        d.MaxCompletionTokens,
+			Reasoning:        d.SupportsReasoning,
+			AdaptiveThinking: usesAdaptiveThinking(model),
+			PriceInput:       d.Pricing.Input,
+			PriceOutput:      d.Pricing.Output,
+			PriceCacheRead:   d.Pricing.CacheRead,
+			PriceCacheWrite:  d.Pricing.CacheWrite,
+			BaseURL:          baseURL,
+			Source:           "live",
+		})
+	}
+	return out, nil
 }
 
 // perMillionTokens converts a per-token USD price string to USD per 1M

--- a/packages/provider/discover_gondola_test.go
+++ b/packages/provider/discover_gondola_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDiscoverGondolaMapsTextModels(t *testing.T) {
+	const body = `{"data":[
+		{"id":"kimi-k3","display_name":"Kimi K3","modality":"text","endpoint":"/v1/chat/completions",
+		 "context_length":1000000,"max_completion_tokens":131072,"supports_reasoning":true,
+		 "pricing":{"input_usd_per_mtok":1.1475,"output_usd_per_mtok":5.7375,"cached_input_usd_per_mtok":0.11475}},
+		{"id":"claude-opus-5","display_name":"Claude Opus 5","modality":"text","endpoint":"/v1/chat/completions",
+		 "context_length":1000000,"max_completion_tokens":128000,"supports_reasoning":true,
+		 "pricing":{"input_usd_per_mtok":1.836,"output_usd_per_mtok":9.18,"cached_input_usd_per_mtok":0.1836,"cache_write_usd_per_mtok":2.295}},
+		{"id":"image","display_name":"Image","modality":"image","endpoint":"/v1/images/generations"},
+		{"id":"wrong-endpoint","display_name":"Wrong endpoint","modality":"text","endpoint":"/v1/messages"},
+		{"id":"","display_name":"Missing ID","modality":"text","endpoint":"/v1/chat/completions"}
+	]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Fatalf("request path = %q", r.URL.Path)
+		}
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	models, err := DiscoverGondola(context.Background(), srv.URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("models = %+v", models)
+	}
+
+	kimi := models[0]
+	if kimi.Provider != "gondola" || kimi.ID != "kimi-k3" || kimi.DisplayName != "Kimi K3" ||
+		kimi.ContextWindow != 1000000 || kimi.MaxOutput != 131072 || !kimi.Reasoning || kimi.AdaptiveThinking ||
+		kimi.PriceInput != 1.1475 || kimi.PriceOutput != 5.7375 || kimi.PriceCacheRead != 0.11475 ||
+		kimi.BaseURL != srv.URL || kimi.Source != "live" {
+		t.Fatalf("kimi model = %+v", kimi)
+	}
+
+	opus := models[1]
+	if opus.ID != "claude-opus-5" || !opus.AdaptiveThinking || opus.PriceCacheRead != 0.1836 || opus.PriceCacheWrite != 2.295 {
+		t.Fatalf("opus model = %+v", opus)
+	}
+}
+
+func TestDiscoverGondolaReportsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := DiscoverGondola(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected discovery error")
+	}
+}

--- a/packages/provider/extra_providers.go
+++ b/packages/provider/extra_providers.go
@@ -119,7 +119,7 @@ func NewOpenRouter(apiKey, baseURL string) Client {
 // NewGondola: Gondola, a USDC-paid marketplace gateway for Venice AI
 // inference. OpenAI Chat Completions-compatible.
 func NewGondola(apiKey, baseURL string) Client {
-	return NewOpenAICompat("gondola", apiKey, baseURL, "https://api.gondola-ai.com/v1")
+	return NewOpenAICompat("gondola", apiKey, baseURL, gondolaDefaultBaseURL)
 }
 
 // NewOpenCode is the opencode.ai Zen endpoint. Mixed APIs upstream; this

--- a/packages/provider/extra_providers.go
+++ b/packages/provider/extra_providers.go
@@ -116,6 +116,12 @@ func NewOpenRouter(apiKey, baseURL string) Client {
 	return NewOpenAICompat("openrouter", apiKey, baseURL, openrouterDefaultBaseURL)
 }
 
+// NewGondola: Gondola, a USDC-paid marketplace gateway for Venice AI
+// inference. OpenAI Chat Completions-compatible.
+func NewGondola(apiKey, baseURL string) Client {
+	return NewOpenAICompat("gondola", apiKey, baseURL, "https://api.gondola-ai.com/v1")
+}
+
 // NewOpenCode is the opencode.ai Zen endpoint. Mixed APIs upstream; this
 // constructor wires the openai-completions flavor only. Models that need
 // the anthropic-messages flavor under the same provider should be built

--- a/packages/provider/labels.go
+++ b/packages/provider/labels.go
@@ -37,6 +37,8 @@ func ProviderLabel(id string) string {
 		return "Hugging Face"
 	case "openrouter":
 		return "OpenRouter"
+	case "gondola":
+		return "Gondola"
 	case "mistral":
 		return "Mistral"
 	case "zai":

--- a/packages/provider/models.go
+++ b/packages/provider/models.go
@@ -255,10 +255,16 @@ var Catalog = []Model{
 	},
 
 	// ---- Gondola ----
-	// Seed entry only: the default model returned by defaultModelForProvider
-	// so it resolves offline. Gondola is a USDC-paid marketplace gateway for
-	// Venice AI inference; prices/limits pulled live from
-	// https://api.gondola-ai.com/v1/models (2026-08-11).
+	// Seed entries only: kimi-k3 is the default returned by
+	// defaultModelForProvider so it resolves offline. Gondola is a USDC-paid
+	// marketplace gateway for Venice AI inference; prices/limits pulled live
+	// from https://api.gondola-ai.com/v1/models (2026-08-11).
+	{
+		Provider: "gondola", ID: "kimi-k3", DisplayName: "Kimi K3 (Gondola)",
+		ContextWindow: 1000000, MaxOutput: 131072, Reasoning: true, AdaptiveThinking: true,
+		PriceInput: 1.1475, PriceOutput: 5.7375,
+		BaseURL: "https://api.gondola-ai.com/v1",
+	},
 	{
 		Provider: "gondola", ID: "claude-opus-5", DisplayName: "Claude Opus 5 (Gondola)",
 		ContextWindow: 1000000, MaxOutput: 128000, Reasoning: true, AdaptiveThinking: true,

--- a/packages/provider/models.go
+++ b/packages/provider/models.go
@@ -254,6 +254,18 @@ var Catalog = []Model{
 		BaseURL: openrouterDefaultBaseURL,
 	},
 
+	// ---- Gondola ----
+	// Seed entry only: the default model returned by defaultModelForProvider
+	// so it resolves offline. Gondola is a USDC-paid marketplace gateway for
+	// Venice AI inference; prices/limits pulled live from
+	// https://api.gondola-ai.com/v1/models (2026-08-11).
+	{
+		Provider: "gondola", ID: "claude-opus-5", DisplayName: "Claude Opus 5 (Gondola)",
+		ContextWindow: 1000000, MaxOutput: 128000, Reasoning: true, AdaptiveThinking: true,
+		PriceInput: 1.836, PriceOutput: 9.18,
+		BaseURL: "https://api.gondola-ai.com/v1",
+	},
+
 	// ---- Speculative: Anthropic ----
 	{
 		Provider: "anthropic", ID: "claude-opus-4-5", DisplayName: "Claude Opus 4.5 (latest)",

--- a/packages/provider/models.go
+++ b/packages/provider/models.go
@@ -261,15 +261,15 @@ var Catalog = []Model{
 	// from https://api.gondola-ai.com/v1/models (2026-08-11).
 	{
 		Provider: "gondola", ID: "kimi-k3", DisplayName: "Kimi K3 (Gondola)",
-		ContextWindow: 1000000, MaxOutput: 131072, Reasoning: true, AdaptiveThinking: true,
-		PriceInput: 1.1475, PriceOutput: 5.7375,
-		BaseURL: "https://api.gondola-ai.com/v1",
+		ContextWindow: 1000000, MaxOutput: 131072, Reasoning: true,
+		PriceInput: 1.1475, PriceOutput: 5.7375, PriceCacheRead: 0.11475,
+		BaseURL: gondolaDefaultBaseURL,
 	},
 	{
 		Provider: "gondola", ID: "claude-opus-5", DisplayName: "Claude Opus 5 (Gondola)",
 		ContextWindow: 1000000, MaxOutput: 128000, Reasoning: true, AdaptiveThinking: true,
-		PriceInput: 1.836, PriceOutput: 9.18,
-		BaseURL: "https://api.gondola-ai.com/v1",
+		PriceInput: 1.836, PriceOutput: 9.18, PriceCacheRead: 0.1836, PriceCacheWrite: 2.295,
+		BaseURL: gondolaDefaultBaseURL,
 	},
 
 	// ---- Speculative: Anthropic ----

--- a/packages/provider/provider_test.go
+++ b/packages/provider/provider_test.go
@@ -346,6 +346,27 @@ func TestClaudeSonnet5Catalog(t *testing.T) {
 	}
 }
 
+func TestGondolaSeedCatalog(t *testing.T) {
+	kimi, err := FindModel("gondola", "kimi-k3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kimi.ContextWindow != 1000000 || kimi.MaxOutput != 131072 || !kimi.Reasoning || kimi.AdaptiveThinking {
+		t.Fatalf("unexpected Kimi K3 model: %+v", kimi)
+	}
+	if kimi.PriceInput != 1.1475 || kimi.PriceOutput != 5.7375 || kimi.PriceCacheRead != 0.11475 {
+		t.Fatalf("unexpected Kimi K3 pricing: %+v", kimi)
+	}
+
+	opus, err := FindModel("gondola", "claude-opus-5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opus.AdaptiveThinking || opus.PriceInput != 1.836 || opus.PriceOutput != 9.18 || opus.PriceCacheRead != 0.1836 || opus.PriceCacheWrite != 2.295 {
+		t.Fatalf("unexpected Claude Opus 5 model: %+v", opus)
+	}
+}
+
 func TestOpenAICompatAnthropicReasoningEffort(t *testing.T) {
 	c := NewOpenRouter("token", "").(*openaiClient)
 	wire, err := c.buildRequest(Request{


### PR DESCRIPTION
Adds **Gondola** (https://gondola-ai.com) following the OpenRouter pattern end to end: `NewGondola` via `NewOpenAICompat` in `extra_providers.go`, registry + env wiring (`GONDOLA_API_KEY`), the `/login` picker and key-probe lists in `auth/`, a display label, seed catalog rows (kimi-k3 as the provider default, Claude Opus 5 beside it) with real prices, and a `docs/providers.md` row. Deliberately skipped `isGatewayProvider()` (its slash-routed model-id handling is OpenRouter-specific; Gondola uses plain catalog ids).

Gondola is a marketplace for Venice AI inference: one OpenAI-compatible endpoint (`https://api.gondola-ai.com/v1`), 105 text models, paid per request in USDC, no subscription. Suppliers compete per request so prices sit below the official APIs; the seed rows' prices come from the live public catalog (`GET /v1/models`, no auth), same source zot can fetch at runtime.

Setup guide for zot users: https://gondola-ai.com/guides/zot