### PR TITLE
Fix empty system prompt override

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ZOT_HOME/
 └── logs/               # app log files
 ```
 
-Drop a `SYSTEM.md` in `$ZOT_HOME` to replace the built-in identity and zot-docs guidance for every run. `--system-prompt` still wins per-invocation. Custom prompts still receive appended instructions and generated context, including `AGENTS.md`, skills, auto-swarm guidance when enabled, and the date/cwd footer. Delete the file to revert to the default.
+Drop a `SYSTEM.md` in `$ZOT_HOME` to replace the built-in identity and zot-docs guidance for every run. `--system-prompt` still wins per-invocation. Pass an empty value (`--system-prompt ""`) to intentionally omit the built-in identity. Custom prompts still receive appended instructions and generated context, including `AGENTS.md`, skills, auto-swarm guidance when enabled, and the date/cwd footer. Delete the file to revert to the default.
 
 ### HTTP proxy
 
@@ -222,7 +222,7 @@ Print-mode stats contain `provider`, `model`, `prompt_tokens`, `reasoning_tokens
 | `--api-key <key>` | Override the API key. |
 | `--base-url <url>` | Override the provider base URL (tests, self-hosted). |
 | `--insecure` | Skip TLS certificate verification for the explicit `--base-url` endpoint or a `baseUrl` defined for a user model in `models.json` (self-signed local/internal inference servers). Built-in providers, auth, and model discovery keep normal TLS verification. |
-| `--system-prompt <text>` | Replace the default system prompt for this run (also overrides `$ZOT_HOME/SYSTEM.md`). |
+| `--system-prompt <text>` | Replace the default system prompt for this run (also overrides `$ZOT_HOME/SYSTEM.md`; pass `""` for no built-in identity). |
 | `--append-system-prompt <text>` | Append text to the system prompt (repeatable). |
 | `--reasoning off\|minimum\|low\|medium\|high\|xhigh\|max` | Set the reasoning level on supported models (default: off). `max` is a separate opt-in tier above `xhigh`. |
 | `--stats <path>` | With `-p`/`--print`, write generation statistics as JSON. |

--- a/docs/zotfiles.md
+++ b/docs/zotfiles.md
@@ -115,7 +115,7 @@ Set `replace_system_prompt` to `true` in the manifest to use `AGENT.md` as the r
 }
 ```
 
-Replacement is intended for fully specialized agents. The default layering behavior is usually preferable because it retains zot's normal identity and tool-use guidance.
+Replacement is intended for fully specialized agents. The default layering behavior is usually preferable because it retains zot's normal identity and tool-use guidance. With replacement enabled, an empty `AGENT.md` intentionally omits the built-in identity while retaining generated context.
 
 ## Bundled skills
 

--- a/packages/agent/args.go
+++ b/packages/agent/args.go
@@ -42,8 +42,11 @@ type Args struct {
 	inheritedAuthMethod string
 	inheritedAccountID  string
 
-	BaseURL            string // override provider base URL (for tests/self-hosted)
-	SystemPrompt       string
+	BaseURL      string // override provider base URL (for tests/self-hosted)
+	SystemPrompt string
+	// SystemPromptSet records whether --system-prompt was provided. An empty
+	// value is an intentional override, distinct from leaving the flag absent.
+	SystemPromptSet    bool
 	AppendSystemPrompt []string
 	Reasoning          string
 	Temperature        *float32
@@ -202,6 +205,7 @@ func ParseArgs(in []string) (Args, error) {
 				return a, err
 			}
 			a.SystemPrompt = v
+			a.SystemPromptSet = true
 		case "--append-system-prompt":
 			v, err := want(&i, arg)
 			if err != nil {

--- a/packages/agent/args_test.go
+++ b/packages/agent/args_test.go
@@ -2,6 +2,19 @@ package agent
 
 import "testing"
 
+func TestParseArgsExplicitEmptySystemPromptIsSet(t *testing.T) {
+	args, err := ParseArgs([]string{"--system-prompt", ""})
+	if err != nil {
+		t.Fatalf("ParseArgs returned %v", err)
+	}
+	if !args.SystemPromptSet {
+		t.Fatal("SystemPromptSet = false; want true for an explicitly empty flag value")
+	}
+	if args.SystemPrompt != "" {
+		t.Fatalf("SystemPrompt = %q; want empty", args.SystemPrompt)
+	}
+}
+
 func TestParseArgsTemperatureAllowsZero(t *testing.T) {
 	args, err := ParseArgs([]string{"--temperature", "0"})
 	if err != nil {

--- a/packages/agent/args_test.go
+++ b/packages/agent/args_test.go
@@ -25,19 +25,6 @@ func TestParseArgsTemperatureAllowsZero(t *testing.T) {
 	}
 }
 
-func TestParseArgsExplicitEmptySystemPromptIsSet(t *testing.T) {
-	args, err := ParseArgs([]string{"--system-prompt", ""})
-	if err != nil {
-		t.Fatalf("ParseArgs returned %v", err)
-	}
-	if !args.SystemPromptSet {
-		t.Fatal("SystemPromptSet = false; want true for an explicitly empty flag value")
-	}
-	if args.SystemPrompt != "" {
-		t.Fatalf("SystemPrompt = %q; want empty", args.SystemPrompt)
-	}
-}
-
 func TestParseArgsTemperatureRejectsOutOfRange(t *testing.T) {
 	if _, err := ParseArgs([]string{"--temperature", "2.1"}); err == nil {
 		t.Fatal("ParseArgs accepted out-of-range temperature")

--- a/packages/agent/args_test.go
+++ b/packages/agent/args_test.go
@@ -12,6 +12,19 @@ func TestParseArgsTemperatureAllowsZero(t *testing.T) {
 	}
 }
 
+func TestParseArgsExplicitEmptySystemPromptIsSet(t *testing.T) {
+	args, err := ParseArgs([]string{"--system-prompt", ""})
+	if err != nil {
+		t.Fatalf("ParseArgs returned %v", err)
+	}
+	if !args.SystemPromptSet {
+		t.Fatal("SystemPromptSet = false; want true for an explicitly empty flag value")
+	}
+	if args.SystemPrompt != "" {
+		t.Fatalf("SystemPrompt = %q; want empty", args.SystemPrompt)
+	}
+}
+
 func TestParseArgsTemperatureRejectsOutOfRange(t *testing.T) {
 	if _, err := ParseArgs([]string{"--temperature", "2.1"}); err == nil {
 		t.Fatal("ParseArgs accepted out-of-range temperature")

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -63,6 +63,7 @@ type Resolved struct {
 	// resolve.
 	systemAppend     []string
 	systemCustom     string
+	systemCustomSet  bool
 	toolDescriptions map[string]string
 }
 
@@ -102,6 +103,7 @@ func (r *Resolved) MergeExtensionTools(mgr ExtensionToolSource) {
 		CWD:        r.CWD,
 		Tools:      toolSummariesFromRegistry(r.ToolRegistry, r.toolDescriptions),
 		Custom:     r.systemCustom,
+		CustomSet:  r.systemCustomSet,
 		Append:     append_,
 		ZotDocsDir: filepath.Join(ZotHome(), "docs"),
 	})
@@ -619,14 +621,17 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 	//   2. $ZOT_HOME/SYSTEM.md (persistent user override)
 	//   3. built-in default (defaultIdentity + defaultGuidelines)
 	custom := args.SystemPrompt
-	if custom == "" {
+	customSet := args.SystemPromptSet || custom != ""
+	if !customSet {
 		custom = readUserSystemPrompt(ZotHome())
+		customSet = custom != ""
 	}
 
 	sys := BuildSystemPrompt(SystemPromptOpts{
 		CWD:        args.CWD,
 		Tools:      summaries,
 		Custom:     custom,
+		CustomSet:  customSet,
 		Append:     append_,
 		ZotDocsDir: docsDir,
 	})
@@ -660,6 +665,7 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 		ContextFiles:     contextFiles,
 		systemAppend:     append_,
 		systemCustom:     custom,
+		systemCustomSet:  customSet,
 		toolDescriptions: descMapFromSummaries(summaries),
 	}, nil
 }

--- a/packages/agent/build_test.go
+++ b/packages/agent/build_test.go
@@ -98,6 +98,34 @@ func TestResolveNoContextFilesSkipsAgentsInstructions(t *testing.T) {
 	}
 }
 
+func TestResolveExplicitEmptySystemPromptOverridesPersistentPrompt(t *testing.T) {
+	zotHome := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("ZOT_HOME", zotHome)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	if err := os.WriteFile(filepath.Join(zotHome, "SYSTEM.md"), []byte("persistent instructions"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Resolve(Args{
+		Provider:        "openai",
+		Model:           "gpt-5",
+		CWD:             cwd,
+		SystemPromptSet: true,
+		SystemPrompt:    "",
+		NoContextFiles:  true,
+		NoSkill:         true,
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"persistent instructions", defaultIdentity, "Zot's own docs are installed under"} {
+		if strings.Contains(r.SystemPrompt, unwanted) {
+			t.Fatalf("explicit empty system prompt unexpectedly contains %q:\n%s", unwanted, r.SystemPrompt)
+		}
+	}
+}
+
 // TestResolveFallsBackWhenConfiguredModelIsGone reproduces the
 // startup failure caught by the user's screenshot: the persisted
 // config.json points at a model id that's no longer in the active

--- a/packages/agent/build_test.go
+++ b/packages/agent/build_test.go
@@ -98,6 +98,33 @@ func TestResolveNoContextFilesSkipsAgentsInstructions(t *testing.T) {
 	}
 }
 
+func TestResolveExplicitEmptySystemPromptOverridesPersistentPrompt(t *testing.T) {
+	zotHome := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("ZOT_HOME", zotHome)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	if err := os.WriteFile(filepath.Join(zotHome, "SYSTEM.md"), []byte("persistent instructions"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Resolve(Args{
+		Provider:        "openai",
+		Model:           "gpt-5",
+		CWD:             cwd,
+		SystemPromptSet: true,
+		NoContextFiles:  true,
+		NoSkill:         true,
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"persistent instructions", defaultIdentity, "Zot's own docs are installed under"} {
+		if strings.Contains(r.SystemPrompt, unwanted) {
+			t.Fatalf("explicit empty system prompt unexpectedly contains %q:\n%s", unwanted, r.SystemPrompt)
+		}
+	}
+}
+
 // TestResolveFallsBackWhenConfiguredModelIsGone reproduces the
 // startup failure caught by the user's screenshot: the persisted
 // config.json points at a model id that's no longer in the active

--- a/packages/agent/sdk/sdk.go
+++ b/packages/agent/sdk/sdk.go
@@ -50,8 +50,13 @@ type Config struct {
 	// process cwd.
 	CWD string
 
-	// SystemPrompt overrides the built-in system prompt.
+	// SystemPrompt overrides the built-in system prompt when non-empty or when
+	// SystemPromptSet is true.
 	SystemPrompt string
+
+	// SystemPromptSet allows an empty SystemPrompt to intentionally omit the
+	// built-in identity. It is unnecessary for non-empty prompts.
+	SystemPromptSet bool
 
 	// AppendSystemPrompt is appended to the built-in (or overridden)
 	// system prompt. Useful for project-specific instructions.
@@ -105,22 +110,7 @@ type Runtime struct {
 // New constructs a Runtime from cfg. Returns an error if no
 // credential is available for the requested provider.
 func New(cfg Config) (*Runtime, error) {
-	args := agent.Args{
-		Mode:               agent.ModeJSON, // headless
-		Provider:           cfg.Provider,
-		Model:              cfg.Model,
-		CWD:                cfg.CWD,
-		APIKey:             cfg.APIKey,
-		BaseURL:            cfg.BaseURL,
-		SystemPrompt:       cfg.SystemPrompt,
-		AppendSystemPrompt: cfg.AppendSystemPrompt,
-		Reasoning:          cfg.Reasoning,
-		Temperature:        cfg.Temperature,
-		MaxSteps:           cfg.MaxSteps,
-		Tools:              cfg.Tools,
-		NoTools:            cfg.NoTools,
-		NoSess:             true, // SDK callers manage persistence themselves
-	}
+	args := argsFromConfig(cfg)
 	if args.MaxSteps == 0 {
 		args.MaxSteps = 50
 	}
@@ -138,6 +128,26 @@ func New(cfg Config) (*Runtime, error) {
 		model:    r.Model,
 		cwd:      r.CWD,
 	}, nil
+}
+
+func argsFromConfig(cfg Config) agent.Args {
+	return agent.Args{
+		Mode:               agent.ModeJSON, // headless
+		Provider:           cfg.Provider,
+		Model:              cfg.Model,
+		CWD:                cfg.CWD,
+		APIKey:             cfg.APIKey,
+		BaseURL:            cfg.BaseURL,
+		SystemPrompt:       cfg.SystemPrompt,
+		SystemPromptSet:    cfg.SystemPromptSet || cfg.SystemPrompt != "",
+		AppendSystemPrompt: cfg.AppendSystemPrompt,
+		Reasoning:          cfg.Reasoning,
+		Temperature:        cfg.Temperature,
+		MaxSteps:           cfg.MaxSteps,
+		Tools:              cfg.Tools,
+		NoTools:            cfg.NoTools,
+		NoSess:             true, // SDK callers manage persistence themselves
+	}
 }
 
 // Provider returns the active provider id.

--- a/packages/agent/sdk/systemprompt_test.go
+++ b/packages/agent/sdk/systemprompt_test.go
@@ -1,0 +1,20 @@
+package sdk
+
+import "testing"
+
+func TestArgsFromConfigPreservesExplicitEmptySystemPrompt(t *testing.T) {
+	args := argsFromConfig(Config{SystemPromptSet: true})
+	if !args.SystemPromptSet {
+		t.Fatal("SystemPromptSet = false; want true for an explicitly empty SDK prompt")
+	}
+	if args.SystemPrompt != "" {
+		t.Fatalf("SystemPrompt = %q; want empty", args.SystemPrompt)
+	}
+}
+
+func TestArgsFromConfigTreatsNonEmptySystemPromptAsSet(t *testing.T) {
+	args := argsFromConfig(Config{SystemPrompt: "custom"})
+	if !args.SystemPromptSet {
+		t.Fatal("SystemPromptSet = false; want true for a non-empty SDK prompt")
+	}
+}

--- a/packages/agent/systemprompt.go
+++ b/packages/agent/systemprompt.go
@@ -21,7 +21,8 @@ type ToolSummary struct {
 type SystemPromptOpts struct {
 	CWD        string
 	Tools      []ToolSummary
-	Custom     string   // if set, replaces the built-in identity and docs guidance
+	Custom     string   // when CustomSet, replaces the built-in identity and docs guidance
+	CustomSet  bool     // preserves an intentionally empty custom prompt
 	Append     []string // extra text appended at the end
 	Now        time.Time
 	ZotDocsDir string
@@ -58,7 +59,7 @@ func BuildSystemPrompt(o SystemPromptOpts) string {
 
 	var sb strings.Builder
 
-	if o.Custom != "" {
+	if o.CustomSet || o.Custom != "" {
 		sb.WriteString(o.Custom)
 	} else {
 		sb.WriteString(defaultIdentity)

--- a/packages/agent/zotfile.go
+++ b/packages/agent/zotfile.go
@@ -151,12 +151,7 @@ func runLocalZotfile(ref string, args Args, version string) error {
 	agentPrompt, err := os.ReadFile(agentPath)
 	switch {
 	case err == nil:
-		text := strings.TrimSpace(string(agentPrompt))
-		if zf.Manifest.ReplaceSystemPrompt {
-			args.SystemPrompt = text
-		} else {
-			args.AppendSystemPrompt = append(args.AppendSystemPrompt, text)
-		}
+		applyZotfileAgentPrompt(&args, zf.Manifest.ReplaceSystemPrompt, string(agentPrompt))
 	case os.IsNotExist(err):
 		// AGENT.md is optional; missing file leaves the system prompt unchanged.
 	default:
@@ -179,6 +174,16 @@ func runLocalZotfile(ref string, args Args, version string) error {
 	args.AgentDataDir = agentData
 	args.PermissionSet = &perms
 	return runWithArgs(args, version)
+}
+
+func applyZotfileAgentPrompt(args *Args, replace bool, prompt string) {
+	text := strings.TrimSpace(prompt)
+	if replace {
+		args.SystemPrompt = text
+		args.SystemPromptSet = true
+		return
+	}
+	args.AppendSystemPrompt = append(args.AppendSystemPrompt, text)
 }
 
 func zotInspect(ref string) error {

--- a/packages/agent/zotfile_test.go
+++ b/packages/agent/zotfile_test.go
@@ -93,6 +93,17 @@ func writeTestZotfile(t *testing.T, manifest string) string {
 	return dir
 }
 
+func TestApplyZotfileAgentPromptPreservesEmptyReplacement(t *testing.T) {
+	args := Args{SystemPrompt: "cli prompt"}
+	applyZotfileAgentPrompt(&args, true, " \n")
+	if !args.SystemPromptSet {
+		t.Fatal("SystemPromptSet = false; want true for an empty replacement AGENT.md")
+	}
+	if args.SystemPrompt != "" {
+		t.Fatalf("SystemPrompt = %q; want empty", args.SystemPrompt)
+	}
+}
+
 func TestLoadZotfileAllowsMissingAgentMD(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(`{"zotfile":1,"name":"test"}`), 0o600); err != nil {


### PR DESCRIPTION
## Summary

Fixes #133.

- preserve whether `--system-prompt` was explicitly supplied, including an empty value
- prevent an empty override from falling back to `$ZOT_HOME/SYSTEM.md` or zot built-ins
- document `--system-prompt ""` as the opt-in empty-prompt behavior

## Root cause

The CLI parser preserved the empty string but not whether the flag was present, so resolution treated it as an omitted flag.

## Validation

- `go test ./packages/agent`
- `go test ./...`
- `go vet ./...`

## Compatibility

Existing non-empty overrides and omitted flags keep their current behavior. Explicit empty overrides now behave as documented.