### PR TITLE
Gate the Kimi deferred-tools handshake to Moonshot providers

### DIFF
--- a/packages/provider/deferred_tools_test.go
+++ b/packages/provider/deferred_tools_test.go
@@ -37,6 +37,45 @@ func TestKimiK3DeferredToolsLoadAtToolResult(t *testing.T) {
 	}
 }
 
+// The deferred-tools handshake is a Moonshot API extension. Another provider
+// serving the same model id must get the standard wire instead: no tools-bearing
+// system message (it carries no content, which strict schemas reject), and the
+// activated tool in the top-level definitions where every provider reads it.
+func TestKimiK3DeferredToolsSkippedForNonMoonshotProvider(t *testing.T) {
+	client := NewGondola("token", "").(*openaiClient)
+	tools := []Tool{
+		{Name: "search_tools", Schema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "lookup_weather", Schema: json.RawMessage(`{"type":"object"}`), Deferred: true},
+	}
+	wire, err := client.buildRequest(Request{
+		Model: "kimi-k3",
+		Tools: tools,
+		Messages: []Message{
+			{Role: RoleUser, Content: []Content{TextBlock{Text: "weather"}}},
+			{Role: RoleAssistant, Content: []Content{ToolCallBlock{ID: "call-1", Name: "search_tools", Arguments: json.RawMessage(`{}`)}}},
+			{Role: RoleTool, Content: []Content{ToolResultBlock{CallID: "call-1", Content: []Content{TextBlock{Text: "found"}}}}, AddedToolNames: []string{"lookup_weather"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, message := range wire.Messages {
+		if len(message.Tools) > 0 {
+			t.Fatalf("message %q carries tools; deferred injection must not reach a non-Moonshot provider", message.Role)
+		}
+		if message.Content == nil && len(message.ToolCalls) == 0 {
+			t.Fatalf("message %q has neither content nor tool calls", message.Role)
+		}
+	}
+	var names []string
+	for _, tool := range wire.Tools {
+		names = append(names, tool.Function.Name)
+	}
+	if len(names) != 2 || names[0] != "search_tools" || names[1] != "lookup_weather" {
+		t.Fatalf("top-level tools = %v, want [search_tools lookup_weather]", names)
+	}
+}
+
 func TestDeferredToolsFallbackToActiveTopLevelDefinitions(t *testing.T) {
 	tools := []Tool{
 		{Name: "base", Schema: json.RawMessage(`{"type":"object"}`)},

--- a/packages/provider/openai.go
+++ b/packages/provider/openai.go
@@ -276,7 +276,7 @@ func (c *openaiClient) buildRequest(req Request) (*oaiRequest, error) {
 		out.Messages = append(out.Messages, oaiMessage{Role: "system", Content: req.System})
 	}
 
-	deferredMode := isKimiDeferredModel(req.Model)
+	deferredMode := supportsDeferredTools(c.Name()) && isKimiDeferredModel(req.Model)
 	toolByName := make(map[string]Tool, len(req.Tools))
 	for _, t := range req.Tools {
 		toolByName[t.Name] = t
@@ -390,6 +390,21 @@ func (c *openaiClient) buildRequest(req Request) (*oaiRequest, error) {
 func isKimiDeferredModel(model string) bool {
 	model = strings.ToLower(model)
 	return model == "kimi-k3" || strings.HasSuffix(model, "/kimi-k3")
+}
+
+// supportsDeferredTools reports whether a provider speaks Moonshot's
+// deferred-tools handshake, where a tool that becomes available mid-conversation
+// is delivered on a system message carrying a `tools` array.
+//
+// That message is a Moonshot API extension, not OpenAI wire format: it has no
+// content, which a strict chat-completions schema rejects outright. Gondola,
+// which serves kimi-k3 on top of Venice, answers "messages.N: Invalid input"
+// and the conversation cannot recover, because the injection is rebuilt from
+// message history on every later turn. Providers outside this list take the
+// standard path instead, where an activated deferred tool joins the top-level
+// tools array.
+func supportsDeferredTools(provider string) bool {
+	return provider == "moonshotai" || provider == "moonshotai-cn"
 }
 
 func makeOAITool(t Tool) oaiTool {


### PR DESCRIPTION
### What breaks today

`deferredMode` is keyed on the model id alone:

```go
deferredMode := isKimiDeferredModel(req.Model)
```

So any OpenAI-compatible provider serving a model named `kimi-k3` receives the Moonshot deferred-tools handshake, where a mid-conversation tool definition rides a system message carrying a `tools` array and no content:

```go
out.Messages = append(out.Messages, oaiMessage{Role: "system", Tools: loaded})
```

`Content interface{}` is `json:"content,omitempty"`, so the key is absent on the wire. Gondola's built-in provider defaults to `kimi-k3`, and its upstream requires content on a system message, so the turn after a deferred tool activates fails:

```
http 400: messages.4: Invalid input
```

The session cannot recover: `AddedToolNames` is persisted on the message and survives history rebuilds, compaction (`packages/core/compact.go`) and session resume (`packages/core/session.go`), so the injection is re-emitted on every later request.

Reproduced on v0.3.43 with a two-tool extension (an ordinary tool whose result names a `DeferredTool` in `ActivateTools`):

```
zot -p --provider gondola --model kimi-k3 "Call load_weather_tool, then call get_weather..."
zot: gondola: http 400: {"error":{"code":"upstream_400","message":"messages.4: Invalid input"}}
```

### Why not just give the message content

Because it would fail silently instead of loudly. That upstream **accepts** a message-level `tools` key and ignores it: a probe carrying tools only on the message made the model hallucinate the tool name rather than emit `tool_calls`. The loaded tool would simply never become callable.

### This change

Gate the handshake on the provider, keeping it for the two Moonshot-native client names and routing everyone else through the standard path that already exists at the bottom of `buildRequest`, where an activated deferred tool joins the top-level `tools` array.

Same repro after the change, full loop, tool called, unchanged server:

```
It is 21C and clear.
```

### Notes

- `TestKimiK3DeferredToolsLoadAtToolResult` builds through `NewMoonshot` and passes unchanged, so the intended path is untouched. The new test asserts the standard wire for `NewGondola`.
- `gofmt`, `go vet`, and `go test ./...` are clean.
- If you would rather carry this as a field on `openaiClient` set by `NewMoonshot`/`NewMoonshotCN` than a provider-name helper, say the word and I will switch it. I kept it a pure function to match `isKimiDeferredModel` and `usesAdaptiveThinking` in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)