### PR TITLE
feat(tools): add built-in glob tool for file pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Yet another coding agent harness, lightweight and written (vibe-slopped) in go.
 
 - one static binary.
 - built-in providers for Anthropic, OpenAI/Codex/Responses, Kimi, DeepSeek, Google Gemini/Vertex, GitHub Copilot, Bedrock, Azure OpenAI, OpenRouter, Groq, Cerebras, xAI, Together, Hugging Face, Mistral, Moonshot, Z.AI, Xiaomi, MiniMax, Fireworks, Vercel AI Gateway, OpenCode, Cloudflare AI, and Ollama/local models.
-- four tools (read, write, edit, bash).
+- built-in tools (read, write, edit, bash, glob).
 - three run modes (interactive tui, print, json).
 - built-in telegram bot.
 - extensions in any language via subprocess + json-rpc. None installed by default; opt in with `zot ext install` or `zot --ext`. See [docs/extensions.md](docs/extensions.md).
@@ -888,7 +888,7 @@ Slash commands also work while the agent is busy. Non-destructive ones (`/help`,
 | `ctrl+d` | Exit on empty input. |
 | `ctrl+l` | Redraw the screen. |
 | `ctrl+v` | Paste clipboard text into the focused chat, side chat, dialog, filter, or credential input. On Linux this uses `wl-paste`, `xclip`, or `xsel`; terminal-native bracketed paste remains available without those commands. In the main chat on macOS, image-only clipboard content is saved as a temporary PNG and attached to the next prompt. |
-| `ctrl+o` | Expand or collapse long tool results (read, write, edit, bash outputs over ~12 lines). |
+| `ctrl+o` | Expand or collapse long tool results (read, write, edit, bash, glob outputs over ~12 lines). |
 | `ctrl+1` ... `ctrl+9` | Switch to the model bound to that quick-model slot (configured in `/settings` -> model shortcuts). No-op while a turn is running. |
 | `@` | Open the file picker. Browse files and directories in the working directory. |
 
@@ -1055,7 +1055,7 @@ packages/agent/extproto/              extension wire-format types
 packages/agent/modes/                 interactive tui, print, json, dialogs
 packages/agent/modes/bot/             protocol-agnostic bot runner (BotAdapter interface)
 packages/agent/modes/telegram/        telegram adapter, api client, daemon
-packages/agent/tools/                 read, write, edit, bash, sandbox
+packages/agent/tools/                 read, write, edit, bash, glob, sandbox
 packages/agent/skills/                skill discovery, frontmatter parser, skill tool
 packages/agent/swarm/                 background subagent runtime
 packages/agent/sdk/                   public Go SDK for embedding zot in-process (package sdk)

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -970,6 +970,8 @@ func (r *Resolved) UseSandbox(s *tools.Sandbox) {
 			v.Sandbox = s
 		case *tools.BashTool:
 			v.Sandbox = s
+		case *tools.GlobTool:
+			v.Sandbox = s
 		}
 		_ = name
 	}
@@ -994,6 +996,7 @@ func buildToolRegistry(args Args, cwd string, sandbox *tools.Sandbox) core.Regis
 		"write": &tools.WriteTool{CWD: cwd, Sandbox: sandbox},
 		"edit":  &tools.EditTool{CWD: cwd, Sandbox: sandbox},
 		"bash":  &tools.BashTool{CWD: cwd, Sandbox: sandbox},
+		"glob":  &tools.GlobTool{CWD: cwd, Sandbox: sandbox},
 	}
 	reg := core.Registry{}
 	if len(args.Tools) == 0 {
@@ -1011,7 +1014,7 @@ func buildToolRegistry(args Args, cwd string, sandbox *tools.Sandbox) core.Regis
 }
 
 func toolSummaries(reg core.Registry, args Args) []ToolSummary {
-	order := []string{"read", "write", "edit", "bash"}
+	order := []string{"read", "write", "edit", "bash", "glob"}
 	var out []ToolSummary
 	for _, name := range order {
 		if t, ok := reg[name]; ok {

--- a/packages/agent/build_test.go
+++ b/packages/agent/build_test.go
@@ -605,3 +605,38 @@ func assertDefaultTransportStillSecure(t *testing.T) {
 		t.Fatal("http.DefaultTransport must not be made insecure")
 	}
 }
+
+func TestBuildToolRegistryIncludesGlob(t *testing.T) {
+	cwd := t.TempDir()
+	reg := buildToolRegistry(Args{}, cwd, nil)
+	expected := []string{"read", "write", "edit", "bash", "glob"}
+	for _, name := range expected {
+		if _, ok := reg[name]; !ok {
+			t.Errorf("expected tool %q in registry, missing", name)
+		}
+	}
+
+	summaries := toolSummaries(reg, Args{})
+	var summaryNames []string
+	for _, s := range summaries {
+		summaryNames = append(summaryNames, s.Name)
+	}
+	for _, name := range expected {
+		found := false
+		for _, sn := range summaryNames {
+			if sn == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected tool %q in toolSummaries, missing", name)
+		}
+	}
+
+	// Filtered tools
+	filtered := buildToolRegistry(Args{Tools: []string{"glob", "read"}}, cwd, nil)
+	if len(filtered) != 2 || filtered["glob"] == nil || filtered["read"] == nil {
+		t.Errorf("expected filtered registry with glob and read, got: %#v", filtered)
+	}
+}

--- a/packages/agent/ext/ext.go
+++ b/packages/agent/ext/ext.go
@@ -390,7 +390,7 @@ func (e *Extension) Command(name, description string, fn CommandHandler) {
 // into the agent's registry once the extension's ready frame fires.
 //
 // Naming conflicts with built-in tools (read, write, edit, bash,
-// skill) are silently shadowed by the built-in.
+// glob, skill) are silently shadowed by the built-in.
 func (e *Extension) Tool(name, description string, schema json.RawMessage, fn ToolHandler) {
 	e.registerTool(name, description, schema, false, fn)
 }

--- a/packages/agent/extensions/intercept_test.go
+++ b/packages/agent/extensions/intercept_test.go
@@ -23,43 +23,50 @@ func TestInterceptAllThreeEvents(t *testing.T) {
 	}
 
 	extDir := t.TempDir()
-	script := `#!/bin/bash
-emit() { printf '%s\n' "$1"; }
-emit '{"type":"hello","name":"itest","version":"0.1.0","capabilities":["events"]}'
-emit '{"type":"subscribe","events":[],"intercept":["tool_call","turn_start","assistant_message"]}'
-emit '{"type":"ready"}'
-while IFS= read -r line; do
-  t=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("type",""))')
-  id=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))')
-  ev=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("event",""))')
-  if [[ "$t" == "shutdown" ]]; then emit '{"type":"shutdown_ack"}'; exit 0; fi
-  if [[ "$t" != "event_intercept" ]]; then continue; fi
-  case "$ev" in
-    tool_call)
-      name=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("tool_name",""))')
-      args=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.dumps(json.load(sys.stdin).get("tool_args",{})))')
-      cmd=$(printf '%s' "$args" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("command",""))')
-      if [[ "$name" == "bash" && "$cmd" == *"rm -rf"* ]]; then
-        emit "{\"type\":\"event_intercept_response\",\"id\":\"$id\",\"block\":true,\"reason\":\"refused: rm -rf\"}"
-      elif [[ "$name" == "bash" && -n "$cmd" ]]; then
-        new=$(python3 -c "import json,sys;print(json.dumps({'command':'echo GUARDED: '+sys.argv[1]}))" "$cmd")
-        emit "{\"type\":\"event_intercept_response\",\"id\":\"$id\",\"modified_args\":$new}"
-      else
-        emit "{\"type\":\"event_intercept_response\",\"id\":\"$id\"}"
-      fi ;;
-    turn_start)
-      emit "{\"type\":\"event_intercept_response\",\"id\":\"$id\"}" ;;
-    assistant_message)
-      text=$(printf '%s' "$line" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("text",""))')
-      if [[ "$text" == *"SECRET"* ]]; then
-        new=$(python3 -c "import sys;print(sys.argv[1].replace('SECRET','[redacted]'))" "$text")
-        rt=$(python3 -c 'import json,sys;print(json.dumps(sys.argv[1]))' "$new")
-        emit "{\"type\":\"event_intercept_response\",\"id\":\"$id\",\"replace_text\":$rt}"
-      else
-        emit "{\"type\":\"event_intercept_response\",\"id\":\"$id\"}"
-      fi ;;
-  esac
-done
+	script := `#!/usr/bin/env python3
+import json, sys
+
+def emit(d):
+    print(json.dumps(d), flush=True)
+
+emit({"type":"hello","name":"itest","version":"0.1.0","capabilities":["events"]})
+emit({"type":"subscribe","events":[],"intercept":["tool_call","turn_start","assistant_message"]})
+emit({"type":"ready"})
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    t = msg.get("type", "")
+    id_ = msg.get("id", "")
+    ev = msg.get("event", "")
+    if t == "shutdown":
+        emit({"type": "shutdown_ack"})
+        sys.exit(0)
+    if t != "event_intercept":
+        continue
+    if ev == "tool_call":
+        name = msg.get("tool_name", "")
+        args = msg.get("tool_args", {})
+        cmd = args.get("command", "") if isinstance(args, dict) else ""
+        if name == "bash" and "rm -rf" in cmd:
+            emit({"type": "event_intercept_response", "id": id_, "block": True, "reason": "refused: rm -rf"})
+        elif name == "bash" and cmd:
+            emit({"type": "event_intercept_response", "id": id_, "modified_args": {"command": "echo GUARDED: " + cmd}})
+        else:
+            emit({"type": "event_intercept_response", "id": id_})
+    elif ev == "turn_start":
+        emit({"type": "event_intercept_response", "id": id_})
+    elif ev == "assistant_message":
+        text = msg.get("text", "")
+        if "SECRET" in text:
+            emit({"type": "event_intercept_response", "id": id_, "replace_text": text.replace("SECRET", "[redacted]")})
+        else:
+            emit({"type": "event_intercept_response", "id": id_})
 `
 	if err := os.WriteFile(filepath.Join(extDir, "ext.sh"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)

--- a/packages/agent/sdk/sdk.go
+++ b/packages/agent/sdk/sdk.go
@@ -79,8 +79,8 @@ type Config struct {
 	// BaseURL overrides the provider base url (for tests / proxies).
 	BaseURL string
 
-	// Tools is the list of tools to enable. Nil/empty = all four
-	// (read, write, edit, bash). Pass an empty-but-non-nil slice
+	// Tools is the list of tools to enable. Nil/empty = all built-ins
+	// (read, write, edit, bash, glob). Pass an empty-but-non-nil slice
 	// (e.g. []string{}) plus NoTools=true to disable everything.
 	Tools []string
 

--- a/packages/agent/tools/glob.go
+++ b/packages/agent/tools/glob.go
@@ -54,114 +54,130 @@ func (t *GlobTool) Execute(ctx context.Context, raw json.RawMessage, progress fu
 		return core.ToolResult{}, err
 	}
 
-	searchDir := resolvePath(t.CWD, a.Path)
-	if err := t.Sandbox.CheckReadPath(searchDir); err != nil {
+	givenSearchDir := resolvePath(t.CWD, a.Path)
+	if err := t.Sandbox.CheckReadPath(givenSearchDir); err != nil {
 		return core.ToolResult{}, err
 	}
 
-	info, err := os.Stat(searchDir)
+	info, err := os.Stat(givenSearchDir)
 	if err != nil {
 		return core.ToolResult{}, err
 	}
 	if !info.IsDir() {
-		shown := t.Sandbox.DisplayPath(searchDir, a.Path)
+		shown := t.Sandbox.DisplayPath(givenSearchDir, a.Path)
 		return core.ToolResult{}, fmt.Errorf("%s is not a directory", shown)
 	}
 
-	stack := ignore.NewStack(searchDir)
+	// WalkDir does not follow a symlink used as its root. Resolve the explicit
+	// search directory so a path that Stat identified as a directory is
+	// actually traversed, then re-check the resolved target before reading it.
+	searchDir, err := filepath.EvalSymlinks(givenSearchDir)
+	if err != nil {
+		return core.ToolResult{}, err
+	}
+	if err := t.Sandbox.CheckReadPath(searchDir); err != nil {
+		return core.ToolResult{}, err
+	}
+
+	stack, ignoreRoot, searchIgnored := t.globIgnoreStack(searchDir)
 	rootSep := strings.Count(searchDir, string(os.PathSeparator))
 	var pushed []string
 	var matches []string
 	truncated := false
 
-	walkErr := filepath.WalkDir(searchDir, func(path string, d os.DirEntry, err error) error {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		if err != nil {
-			if d != nil && d.IsDir() {
+	var walkErr error
+	if !searchIgnored {
+		walkErr = filepath.WalkDir(searchDir, func(path string, d os.DirEntry, err error) error {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			if err != nil {
+				if d != nil && d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if path == searchDir {
+				return nil
+			}
+
+			rel, relErr := filepath.Rel(searchDir, path)
+			if relErr != nil {
+				return nil
+			}
+			relSlash := filepath.ToSlash(rel)
+
+			// Check hidden files/directories unless explicitly requested.
+			// .git is always skipped.
+			if !a.Hidden {
+				if strings.HasPrefix(d.Name(), ".") {
+					if d.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+			} else if d.IsDir() && d.Name() == ".git" {
 				return filepath.SkipDir
 			}
-			return nil
-		}
-		if path == searchDir {
-			return nil
-		}
 
-		rel, relErr := filepath.Rel(searchDir, path)
-		if relErr != nil {
-			return nil
-		}
-		relSlash := filepath.ToSlash(rel)
+			ignoreRel, ignoreRelErr := filepath.Rel(ignoreRoot, path)
+			if ignoreRelErr != nil {
+				return nil
+			}
+			ignoreRelSlash := filepath.ToSlash(ignoreRel)
 
-		// Check hidden files/directories unless explicitly requested.
-		// .git is always skipped.
-		if !a.Hidden {
-			if strings.HasPrefix(d.Name(), ".") {
+			// .gitignore filtering: pop stack frames for directories no longer in scope.
+			dirSlash := relSlash
+			if !d.IsDir() {
+				if idx := strings.LastIndex(relSlash, "/"); idx >= 0 {
+					dirSlash = relSlash[:idx]
+				} else {
+					dirSlash = ""
+				}
+			}
+			for len(pushed) > 0 {
+				top := pushed[len(pushed)-1]
+				if top == dirSlash || strings.HasPrefix(dirSlash, top+"/") {
+					break
+				}
+				pushed = pushed[:len(pushed)-1]
+				stack.Pop()
+			}
+
+			if stack.Match(ignoreRelSlash, d.IsDir()) {
 				if d.IsDir() {
 					return filepath.SkipDir
 				}
 				return nil
 			}
-		} else if d.IsDir() && d.Name() == ".git" {
-			return filepath.SkipDir
-		}
 
-		// .gitignore filtering: pop stack frames for directories no longer in scope.
-		dirSlash := relSlash
-		if !d.IsDir() {
-			if idx := strings.LastIndex(relSlash, "/"); idx >= 0 {
-				dirSlash = relSlash[:idx]
-			} else {
-				dirSlash = ""
-			}
-		}
-		for len(pushed) > 0 {
-			top := pushed[len(pushed)-1]
-			if top == dirSlash || strings.HasPrefix(dirSlash, top+"/") {
-				break
-			}
-			pushed = pushed[:len(pushed)-1]
-			stack.Pop()
-		}
-
-		if stack.Match(relSlash, d.IsDir()) {
 			if d.IsDir() {
-				return filepath.SkipDir
+				if strings.Count(path, string(os.PathSeparator))-rootSep >= maxGlobDepth {
+					return filepath.SkipDir
+				}
+				stack.Push(path, ignoreRel)
+				pushed = append(pushed, relSlash)
+				return nil
+			}
+
+			// Check if file matches the glob pattern.
+			matched := false
+			if hasSlash {
+				matched = re.MatchString(relSlash)
+			} else {
+				matched = re.MatchString(d.Name())
+			}
+
+			if matched {
+				matches = append(matches, t.globDisplayPath(givenSearchDir, a.Path, relSlash))
+				if len(matches) >= maxGlobMatches {
+					truncated = true
+					return filepath.SkipAll
+				}
 			}
 			return nil
-		}
-
-		if d.IsDir() {
-			if strings.Count(path, string(os.PathSeparator))-rootSep >= maxGlobDepth {
-				return filepath.SkipDir
-			}
-			stack.Push(path, rel)
-			pushed = append(pushed, relSlash)
-			return nil
-		}
-
-		// Check if file matches the glob pattern.
-		matched := false
-		if hasSlash {
-			matched = re.MatchString(relSlash)
-		} else {
-			matched = re.MatchString(d.Name())
-		}
-
-		if matched {
-			disp := relSlash
-			if a.Path != "" && a.Path != "." {
-				disp = filepath.ToSlash(filepath.Join(a.Path, rel))
-			}
-			matches = append(matches, disp)
-			if len(matches) >= maxGlobMatches {
-				truncated = true
-				return filepath.SkipAll
-			}
-		}
-		return nil
-	})
+		})
+	}
 
 	if walkErr != nil && walkErr != filepath.SkipAll {
 		return core.ToolResult{}, walkErr
@@ -187,6 +203,51 @@ func (t *GlobTool) Execute(ctx context.Context, raw json.RawMessage, progress fu
 			"pattern":   a.Pattern,
 		},
 	}, nil
+}
+
+// globIgnoreStack builds an ignore stack rooted at CWD when the search path is
+// below it, preloading the .gitignore files between CWD and the search root.
+// This preserves inherited rules when the caller narrows a search with path.
+func (t *GlobTool) globIgnoreStack(searchDir string) (*ignore.Stack, string, bool) {
+	cwd := resolvePath(t.CWD, ".")
+	cwd, err := filepath.EvalSymlinks(cwd)
+	if err != nil || t.Sandbox.CheckReadPath(cwd) != nil {
+		return ignore.NewStack(searchDir), searchDir, false
+	}
+
+	rel, err := filepath.Rel(cwd, searchDir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return ignore.NewStack(searchDir), searchDir, false
+	}
+
+	stack := ignore.NewStack(cwd)
+	if rel == "." {
+		return stack, cwd, false
+	}
+
+	current := cwd
+	var relParts []string
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		current = filepath.Join(current, part)
+		relParts = append(relParts, part)
+		currentRel := filepath.Join(relParts...)
+		if stack.Match(filepath.ToSlash(currentRel), true) {
+			return stack, cwd, true
+		}
+		stack.Push(current, currentRel)
+	}
+	return stack, cwd, false
+}
+
+func (t *GlobTool) globDisplayPath(searchDir, given, relSlash string) string {
+	if given == "" || given == "." {
+		return relSlash
+	}
+	prefix := filepath.ToSlash(t.Sandbox.DisplayPath(searchDir, given))
+	if prefix == "" || prefix == "." {
+		return relSlash
+	}
+	return strings.TrimSuffix(prefix, "/") + "/" + relSlash
 }
 
 // compileGlob converts a glob pattern into a regular expression.

--- a/packages/agent/tools/glob.go
+++ b/packages/agent/tools/glob.go
@@ -1,0 +1,294 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/patriceckhart/zot/packages/core"
+	"github.com/patriceckhart/zot/packages/ignore"
+	"github.com/patriceckhart/zot/packages/provider"
+)
+
+const (
+	maxGlobMatches = 500
+	maxGlobDepth   = 24
+)
+
+// GlobTool finds files matching a pattern within a directory tree.
+type GlobTool struct {
+	CWD     string
+	Sandbox *Sandbox
+}
+
+type globArgs struct {
+	Pattern string `json:"pattern"`
+	Path    string `json:"path,omitempty"`
+	Hidden  bool   `json:"hidden,omitempty"`
+}
+
+const globSchema = `{"type":"object","properties":{"pattern":{"type":"string","description":"Glob pattern to match files against (e.g. \"**/*.go\", \"*.json\", \"src/**/*.ts\")"},"path":{"type":"string","description":"Directory to search within, relative to CWD (defaults to \".\")"},"hidden":{"type":"boolean","description":"Whether to include hidden files and directories (default false)"}},"required":["pattern"]}`
+
+func (t *GlobTool) Name() string { return "glob" }
+func (t *GlobTool) Description() string {
+	return "Find files matching a glob pattern (e.g. \"**/*.go\", \"*.json\", \"src/**/*.ts\"). Honors .gitignore rules."
+}
+func (t *GlobTool) Schema() json.RawMessage { return json.RawMessage(globSchema) }
+
+func (t *GlobTool) Execute(ctx context.Context, raw json.RawMessage, progress func(string)) (core.ToolResult, error) {
+	var a globArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return core.ToolResult{}, fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(a.Pattern) == "" {
+		return core.ToolResult{}, fmt.Errorf("pattern is required")
+	}
+
+	re, hasSlash, err := compileGlob(a.Pattern)
+	if err != nil {
+		return core.ToolResult{}, err
+	}
+
+	searchDir := resolvePath(t.CWD, a.Path)
+	if err := t.Sandbox.CheckReadPath(searchDir); err != nil {
+		return core.ToolResult{}, err
+	}
+
+	info, err := os.Stat(searchDir)
+	if err != nil {
+		return core.ToolResult{}, err
+	}
+	if !info.IsDir() {
+		shown := t.Sandbox.DisplayPath(searchDir, a.Path)
+		return core.ToolResult{}, fmt.Errorf("%s is not a directory", shown)
+	}
+
+	stack := ignore.NewStack(searchDir)
+	rootSep := strings.Count(searchDir, string(os.PathSeparator))
+	var pushed []string
+	var matches []string
+	truncated := false
+
+	walkErr := filepath.WalkDir(searchDir, func(path string, d os.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if path == searchDir {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(searchDir, path)
+		if relErr != nil {
+			return nil
+		}
+		relSlash := filepath.ToSlash(rel)
+
+		// Check hidden files/directories unless explicitly requested.
+		// .git is always skipped.
+		if !a.Hidden {
+			if strings.HasPrefix(d.Name(), ".") {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		} else if d.IsDir() && d.Name() == ".git" {
+			return filepath.SkipDir
+		}
+
+		// .gitignore filtering: pop stack frames for directories no longer in scope.
+		dirSlash := relSlash
+		if !d.IsDir() {
+			if idx := strings.LastIndex(relSlash, "/"); idx >= 0 {
+				dirSlash = relSlash[:idx]
+			} else {
+				dirSlash = ""
+			}
+		}
+		for len(pushed) > 0 {
+			top := pushed[len(pushed)-1]
+			if top == dirSlash || strings.HasPrefix(dirSlash, top+"/") {
+				break
+			}
+			pushed = pushed[:len(pushed)-1]
+			stack.Pop()
+		}
+
+		if stack.Match(relSlash, d.IsDir()) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			if strings.Count(path, string(os.PathSeparator))-rootSep >= maxGlobDepth {
+				return filepath.SkipDir
+			}
+			stack.Push(path, rel)
+			pushed = append(pushed, relSlash)
+			return nil
+		}
+
+		// Check if file matches the glob pattern.
+		matched := false
+		if hasSlash {
+			matched = re.MatchString(relSlash)
+		} else {
+			matched = re.MatchString(d.Name())
+		}
+
+		if matched {
+			disp := relSlash
+			if a.Path != "" && a.Path != "." {
+				disp = filepath.ToSlash(filepath.Join(a.Path, rel))
+			}
+			matches = append(matches, disp)
+			if len(matches) >= maxGlobMatches {
+				truncated = true
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+
+	if walkErr != nil && walkErr != filepath.SkipAll {
+		return core.ToolResult{}, walkErr
+	}
+
+	sort.Strings(matches)
+
+	var text string
+	if len(matches) == 0 {
+		text = "No files matched the pattern."
+	} else {
+		text = strings.Join(matches, "\n")
+		if truncated {
+			text += fmt.Sprintf("\n\n(Truncated: showing first %d matches)", maxGlobMatches)
+		}
+	}
+
+	return core.ToolResult{
+		Content: []provider.Content{provider.TextBlock{Text: text}},
+		Details: map[string]any{
+			"matches":   len(matches),
+			"truncated": truncated,
+			"pattern":   a.Pattern,
+		},
+	}, nil
+}
+
+// compileGlob converts a glob pattern into a regular expression.
+// It supports '*', '**', '?', character classes '[...]', and brace expansion '{a,b}'.
+func compileGlob(pattern string) (*regexp.Regexp, bool, error) {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	pattern = strings.TrimPrefix(pattern, "./")
+	if pattern == "" {
+		return nil, false, fmt.Errorf("empty pattern")
+	}
+
+	hasSlash := strings.Contains(pattern, "/")
+
+	var sb strings.Builder
+	sb.WriteString("^")
+
+	inBrace := false
+	i := 0
+	n := len(pattern)
+	for i < n {
+		c := pattern[i]
+		switch c {
+		case '*':
+			if i+1 < n && pattern[i+1] == '*' {
+				i += 2
+				if i < n && pattern[i] == '/' {
+					i++
+					sb.WriteString("(?:.*/)?")
+				} else {
+					sb.WriteString(".*")
+				}
+			} else {
+				i++
+				if hasSlash {
+					sb.WriteString("[^/]*")
+				} else {
+					sb.WriteString(".*")
+				}
+			}
+		case '?':
+			i++
+			if hasSlash {
+				sb.WriteString("[^/]")
+			} else {
+				sb.WriteString(".")
+			}
+		case '{':
+			closeIdx := strings.IndexByte(pattern[i:], '}')
+			if closeIdx > 0 && strings.Contains(pattern[i:i+closeIdx], ",") {
+				inBrace = true
+				sb.WriteString("(?:")
+				i++
+			} else {
+				sb.WriteString("\\{")
+				i++
+			}
+		case ',':
+			if inBrace {
+				sb.WriteString("|")
+				i++
+			} else {
+				sb.WriteString(",")
+				i++
+			}
+		case '}':
+			if inBrace {
+				sb.WriteString(")")
+				inBrace = false
+				i++
+			} else {
+				sb.WriteString("\\}")
+				i++
+			}
+		case '[':
+			j := i + 1
+			if j < n && pattern[j] == ']' {
+				j++
+			}
+			for j < n && pattern[j] != ']' {
+				j++
+			}
+			if j < n {
+				sb.WriteString(pattern[i : j+1])
+				i = j + 1
+			} else {
+				sb.WriteString("\\[")
+				i++
+			}
+		case '.', '+', '(', ')', '^', '$', '|', '\\':
+			sb.WriteByte('\\')
+			sb.WriteByte(c)
+			i++
+		default:
+			sb.WriteByte(c)
+			i++
+		}
+	}
+	sb.WriteString("$")
+
+	re, err := regexp.Compile(sb.String())
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
+	}
+	return re, hasSlash, nil
+}

--- a/packages/agent/tools/glob_test.go
+++ b/packages/agent/tools/glob_test.go
@@ -1,0 +1,303 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patriceckhart/zot/packages/provider"
+)
+
+func TestGlobBasic(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"main.go",
+		"README.md",
+		"pkg/util.go",
+		"pkg/util_test.go",
+		"pkg/sub/deep.go",
+		"docs/index.html",
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tool := &GlobTool{CWD: dir}
+
+	// 1. Simple extension match across tree (no slash in pattern)
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go"}), nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	for _, want := range []string{"main.go", "pkg/util.go", "pkg/util_test.go", "pkg/sub/deep.go"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("expected %q in result, got:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "README.md") || strings.Contains(text, "docs/index.html") {
+		t.Errorf("unexpected file in result:\n%s", text)
+	}
+
+	// 2. Globstar match with path prefix
+	res, err = tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "pkg/**/*.go"}), nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	text = res.Content[0].(provider.TextBlock).Text
+	if strings.Contains(text, "main.go") {
+		t.Errorf("did not expect main.go in pkg/**/*.go, got:\n%s", text)
+	}
+	for _, want := range []string{"pkg/util.go", "pkg/util_test.go", "pkg/sub/deep.go"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("expected %q in result, got:\n%s", want, text)
+		}
+	}
+
+	// 3. Specific path segment
+	res, err = tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "pkg/*.go"}), nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	text = res.Content[0].(provider.TextBlock).Text
+	if strings.Contains(text, "pkg/sub/deep.go") {
+		t.Errorf("did not expect deep.go in single-star pkg/*.go, got:\n%s", text)
+	}
+	if !strings.Contains(text, "pkg/util.go") || !strings.Contains(text, "pkg/util_test.go") {
+		t.Errorf("missing pkg/util.go in pkg/*.go, got:\n%s", text)
+	}
+}
+
+func TestGlobBraceExpansion(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"a.go",
+		"b.json",
+		"c.ts",
+		"d.txt",
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f)
+		os.WriteFile(p, []byte("content"), 0o644)
+	}
+
+	tool := &GlobTool{CWD: dir}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.{go,json}"}), nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	if !strings.Contains(text, "a.go") || !strings.Contains(text, "b.json") {
+		t.Errorf("expected a.go and b.json, got:\n%s", text)
+	}
+	if strings.Contains(text, "c.ts") || strings.Contains(text, "d.txt") {
+		t.Errorf("unexpected files in result:\n%s", text)
+	}
+}
+
+func TestGlobGitignore(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("ignored/\n*.log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []string{
+		"app.go",
+		"error.log",
+		"ignored/secret.go",
+		"sub/normal.go",
+		"sub/test.log",
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f)
+		os.MkdirAll(filepath.Dir(p), 0o755)
+		os.WriteFile(p, []byte("content"), 0o644)
+	}
+
+	tool := &GlobTool{CWD: dir}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "**/*"}), nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	if strings.Contains(text, "secret.go") || strings.Contains(text, "error.log") || strings.Contains(text, "test.log") {
+		t.Errorf("result contains gitignored files:\n%s", text)
+	}
+	if !strings.Contains(text, "app.go") || !strings.Contains(text, "sub/normal.go") {
+		t.Errorf("missing tracked files in:\n%s", text)
+	}
+}
+
+func TestGlobNestedGitignore(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "vendor")
+	os.MkdirAll(nested, 0o755)
+	os.WriteFile(filepath.Join(nested, ".gitignore"), []byte("cached/\n"), 0o644)
+
+	files := []string{
+		"root.go",
+		"vendor/keep.go",
+		"vendor/cached/temp.go",
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f)
+		os.MkdirAll(filepath.Dir(p), 0o755)
+		os.WriteFile(p, []byte("content"), 0o644)
+	}
+
+	tool := &GlobTool{CWD: dir}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "**/*.go"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	if strings.Contains(text, "temp.go") {
+		t.Errorf("nested gitignore rule was not respected: %s", text)
+	}
+	if !strings.Contains(text, "root.go") || !strings.Contains(text, "vendor/keep.go") {
+		t.Errorf("expected files missing: %s", text)
+	}
+}
+
+func TestGlobHiddenFiles(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"visible.txt",
+		".hidden.txt",
+		".config/settings.json",
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f)
+		os.MkdirAll(filepath.Dir(p), 0o755)
+		os.WriteFile(p, []byte("content"), 0o644)
+	}
+
+	tool := &GlobTool{CWD: dir}
+
+	// Default: skip hidden
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.*"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	if strings.Contains(text, ".hidden.txt") || strings.Contains(text, "settings.json") {
+		t.Errorf("hidden files should be skipped by default: %s", text)
+	}
+	if !strings.Contains(text, "visible.txt") {
+		t.Errorf("visible.txt missing: %s", text)
+	}
+
+	// Hidden: true
+	res, err = tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "**/*", "hidden": true}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text = res.Content[0].(provider.TextBlock).Text
+	if !strings.Contains(text, ".hidden.txt") || !strings.Contains(text, ".config/settings.json") {
+		t.Errorf("hidden files missing when hidden=true: %s", text)
+	}
+}
+
+func TestGlobSubdirectoryPath(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"root.txt",
+		"sub/a.txt",
+		"sub/b.txt",
+		"other/c.txt",
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f)
+		os.MkdirAll(filepath.Dir(p), 0o755)
+		os.WriteFile(p, []byte("content"), 0o644)
+	}
+
+	tool := &GlobTool{CWD: dir}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.txt", "path": "sub"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	if strings.Contains(text, "root.txt") || strings.Contains(text, "other/c.txt") {
+		t.Errorf("result should only contain files from sub: %s", text)
+	}
+	if !strings.Contains(text, "sub/a.txt") || !strings.Contains(text, "sub/b.txt") {
+		t.Errorf("sub files missing: %s", text)
+	}
+}
+
+func TestGlobNoMatches(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644)
+
+	tool := &GlobTool{CWD: dir}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.rs"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	if text != "No files matched the pattern." {
+		t.Fatalf("expected 'No files matched the pattern.', got: %q", text)
+	}
+	details := res.Details.(map[string]any)
+	if details["matches"] != 0 {
+		t.Fatalf("matches detail want 0, got %v", details["matches"])
+	}
+}
+
+func TestGlobValidationErrors(t *testing.T) {
+	dir := t.TempDir()
+	tool := &GlobTool{CWD: dir}
+
+	// Empty pattern
+	if _, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": ""}), nil); err == nil {
+		t.Fatal("expected error for empty pattern")
+	}
+
+	// Non-existent directory
+	if _, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go", "path": "nonexistent"}), nil); err == nil {
+		t.Fatal("expected error for non-existent path")
+	}
+
+	// File instead of directory
+	filePath := filepath.Join(dir, "file.txt")
+	os.WriteFile(filePath, []byte("text"), 0o644)
+	if _, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.txt", "path": "file.txt"}), nil); err == nil {
+		t.Fatal("expected error for file passed as path")
+	}
+}
+
+func TestGlobSandboxing(t *testing.T) {
+	dir := t.TempDir()
+	sandboxDir := filepath.Join(dir, "sandbox")
+	outsideDir := filepath.Join(dir, "outside")
+	os.MkdirAll(sandboxDir, 0o755)
+	os.MkdirAll(outsideDir, 0o755)
+
+	s := NewSandbox(sandboxDir)
+	s.Lock()
+
+	tool := &GlobTool{CWD: sandboxDir, Sandbox: s}
+
+	// Inside sandbox should succeed
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go"}), nil)
+	if err != nil {
+		t.Fatalf("expected success inside sandbox, got %v", err)
+	}
+	if res.Content[0].(provider.TextBlock).Text != "No files matched the pattern." {
+		t.Fatalf("unexpected content: %v", res.Content[0])
+	}
+
+	// Outside sandbox should fail
+	if _, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go", "path": outsideDir}), nil); err == nil {
+		t.Fatal("expected sandboxing error for path outside sandbox")
+	}
+}

--- a/packages/agent/tools/glob_test.go
+++ b/packages/agent/tools/glob_test.go
@@ -234,6 +234,57 @@ func TestGlobSubdirectoryPath(t *testing.T) {
 	}
 }
 
+func TestGlobSubdirectoryHonorsParentGitignore(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("sub/ignored.go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"ignored.go", "kept.go"} {
+		if err := os.WriteFile(filepath.Join(dir, "sub", name), []byte("content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tool := &GlobTool{CWD: dir}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go", "path": "sub"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := res.Content[0].(provider.TextBlock).Text
+	if strings.Contains(text, "ignored.go") {
+		t.Fatalf("parent .gitignore rule was not respected: %s", text)
+	}
+	if !strings.Contains(text, "sub/kept.go") {
+		t.Fatalf("expected kept file in result: %s", text)
+	}
+}
+
+func TestGlobSymlinkSearchRoot(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "found.go"), []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	tool := &GlobTool{CWD: dir}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go", "path": "link"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := res.Content[0].(provider.TextBlock).Text; text != "link/found.go" {
+		t.Fatalf("unexpected symlink search result: %q", text)
+	}
+}
+
 func TestGlobNoMatches(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644)
@@ -296,7 +347,20 @@ func TestGlobSandboxing(t *testing.T) {
 		t.Fatalf("unexpected content: %v", res.Content[0])
 	}
 
-	// Outside sandbox should fail
+	// Absolute paths inside the sandbox should not leak the sandbox root.
+	insideFile := filepath.Join(sandboxDir, "inside.go")
+	if err := os.WriteFile(insideFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go", "path": sandboxDir}), nil)
+	if err != nil {
+		t.Fatalf("expected absolute path inside sandbox to succeed, got %v", err)
+	}
+	if text := res.Content[0].(provider.TextBlock).Text; text != "inside.go" {
+		t.Fatalf("jailed result should be relative, got %q", text)
+	}
+
+	// Outside sandbox should fail.
 	if _, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go", "path": outsideDir}), nil); err == nil {
 		t.Fatal("expected sandboxing error for path outside sandbox")
 	}

--- a/packages/agent/tools/read.go
+++ b/packages/agent/tools/read.go
@@ -1,4 +1,4 @@
-// Package tools implements zot's built-in tools: read, write, edit, bash.
+// Package tools implements zot's built-in tools: read, write, edit, bash, glob.
 package tools
 
 import (

--- a/packages/tui/view.go
+++ b/packages/tui/view.go
@@ -2274,7 +2274,7 @@ func ShortArgs(tool string, raw json.RawMessage) string {
 		return s
 	}
 	var primary string
-	for _, k := range []string{"path", "file_path", "command"} {
+	for _, k := range []string{"pattern", "path", "file_path", "command"} {
 		if s, ok := x[k].(string); ok {
 			primary = s
 			break
@@ -2290,8 +2290,7 @@ func ShortArgs(tool string, raw json.RawMessage) string {
 	}
 	primary = oneLineToolLabel(primary)
 
-	// Tool-specific decoration. Only the read tool gets a range
-	// suffix for now; other tools just truncate the primary arg.
+	// Tool-specific decoration.
 	suffix := ""
 	switch strings.ToLower(tool) {
 	case "read":
@@ -2304,6 +2303,10 @@ func ShortArgs(tool string, raw json.RawMessage) string {
 			suffix = fmt.Sprintf(":%d-%d", start, end)
 		} else if start > 1 {
 			suffix = fmt.Sprintf(":%d-", start)
+		}
+	case "glob":
+		if dir, ok := x["path"].(string); ok && dir != "" && dir != "." {
+			suffix = " in " + dir
 		}
 	}
 


### PR DESCRIPTION
## Summary
This pull request adds a built-in `glob` tool to `zot` for fast, sandboxed file pattern matching that respects `.gitignore` rules.

### Capabilities & Details
- **`GlobTool` (`packages/agent/tools/glob.go`)**:
  - Finds files matching glob patterns such as `**/*.go`, `*.json`, `src/**/*.ts`, `pkg/**/test_*.go`.
  - Supports `*`, `**` (globstar across path segments), `?`, `[...]` character classes, and `{a,b}` brace expansion.
  - Automatically respects root and nested `.gitignore` files using `ignore.Stack`.
  - Supports search root selection via optional `path` parameter.
  - Supports optional `hidden` flag to include/exclude hidden files (skipping `.git` always).
  - Enforces `Sandbox.CheckReadPath` when jailed and bounds max matches and recursion depth.
- **Integration**:
  - Registered in `packages/agent/build.go` (`buildToolRegistry`, `UseSandbox`, and `toolSummaries`).
  - Added TUI formatted presentation support in `packages/tui/view.go` (`shortArgs`).
  - Updated documentation in `README.md`, `packages/agent/sdk/sdk.go`, and `packages/agent/ext/ext.go`.
- **Testing**:
  - Comprehensive unit tests added in `packages/agent/tools/glob_test.go` and `packages/agent/build_test.go`.
  - All tests (`go test ./...`) pass cleanly with `make lint` and `make build` verifying format and build validity.