### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/examples/extensions/mcp-bridge/README.md
+++ b/examples/extensions/mcp-bridge/README.md
@@ -225,21 +225,26 @@ Standard MCP config — same as Claude Desktop, with zot-specific extensions:
 ### You.com template
 
 `/mcp setup add you` registers the keyless You.com MCP profile
-(`you-search`). It needs no account or API key. To move to the
-authenticated server with the full You.com tool set, edit
-`$ZOT_HOME/mcp.json` after adding the template:
+(`you-search`). It needs no account or API key. To use the authenticated
+server and its additional tools, edit `$ZOT_HOME/mcp.json` after adding
+the template:
 
 ```jsonc
 {
-  "you": {
-    "transport": "streamable-http",
-    "url": "https://api.you.com/mcp",
-    "headers": {
-      "Authorization": "Bearer YOUR_YDC_API_KEY"
+  "mcpServers": {
+    "you": {
+      "transport": "streamable-http",
+      "url": "https://api.you.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_YDC_API_KEY"
+      }
     }
   }
 }
 ```
+
+The authenticated endpoint does not expose `you-finance` by default. Request
+it explicitly with the `?tools=` URL parameter or the `X-Allowed-Tools` header.
 
 ## How It Works
 

--- a/examples/extensions/mcp-bridge/README.md
+++ b/examples/extensions/mcp-bridge/README.md
@@ -211,6 +211,31 @@ Standard MCP config — same as Claude Desktop, with zot-specific extensions:
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"]
+    },
+
+    // You.com web search (streamable-http, keyless)
+    "you": {
+      "transport": "streamable-http",
+      "url": "https://api.you.com/mcp?profile=free"
+    }
+  }
+}
+```
+
+### You.com template
+
+`/mcp setup add you` registers the keyless You.com MCP profile
+(`you-search`). It needs no account or API key. To move to the
+authenticated server with the full You.com tool set, edit
+`$ZOT_HOME/mcp.json` after adding the template:
+
+```jsonc
+{
+  "you": {
+    "transport": "streamable-http",
+    "url": "https://api.you.com/mcp",
+    "headers": {
+      "Authorization": "Bearer YOUR_YDC_API_KEY"
     }
   }
 }

--- a/examples/extensions/mcp-bridge/setup.go
+++ b/examples/extensions/mcp-bridge/setup.go
@@ -64,7 +64,7 @@ func setupTemplates() map[string]serverTemplate {
 		},
 		"you": {
 			Name:        "you",
-			Description: "Current web search via the keyless You.com MCP server (you-search). Add an Authorization Bearer header with a YDC_API_KEY for the full tool set.",
+			Description: "Current web search via the keyless You.com MCP server (you-search). Add an Authorization Bearer header with a YDC_API_KEY for additional authenticated tools.",
 			Config: func(cwd string) ServerConfig {
 				return ServerConfig{
 					Transport: "streamable-http",

--- a/examples/extensions/mcp-bridge/setup.go
+++ b/examples/extensions/mcp-bridge/setup.go
@@ -62,6 +62,16 @@ func setupTemplates() map[string]serverTemplate {
 				}
 			},
 		},
+		"you": {
+			Name:        "you",
+			Description: "Current web search via the keyless You.com MCP server (you-search). Add an Authorization Bearer header with a YDC_API_KEY for the full tool set.",
+			Config: func(cwd string) ServerConfig {
+				return ServerConfig{
+					Transport: "streamable-http",
+					URL:       "https://api.you.com/mcp?profile=free",
+				}
+			},
+		},
 	}
 }
 

--- a/examples/extensions/mcp-bridge/setup_test.go
+++ b/examples/extensions/mcp-bridge/setup_test.go
@@ -58,6 +58,35 @@ func TestHandleSetupAddFilesystemProject(t *testing.T) {
 	}
 }
 
+func TestHandleSetupAddYouGlobal(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("ZOT_HOME", tmp)
+
+	out, err := handleSetup([]string{"add", "you"}, tmp)
+	if err != nil {
+		t.Fatalf("handleSetup add you: %v", err)
+	}
+	if out == "" {
+		t.Fatal("expected setup output")
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmp, "mcp.json"))
+	if err != nil {
+		t.Fatalf("read mcp.json: %v", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse mcp.json: %v", err)
+	}
+	you := cfg.MCPServers["you"]
+	if you.Transport != "streamable-http" || you.URL != "https://api.you.com/mcp?profile=free" {
+		t.Fatalf("unexpected you config: %+v", you)
+	}
+	if len(you.Headers) != 0 {
+		t.Fatalf("keyless template must not write auth headers: %+v", you.Headers)
+	}
+}
+
 func TestHandleSetupDuplicate(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("ZOT_HOME", tmp)


### PR DESCRIPTION
zot's mcp-bridge ships a small set of setup templates (`/mcp setup templates`) for common MCP servers — grep.app, filesystem, context7, playwright. This adds a `you` template for the You.com MCP server, so web search is a one-command opt-in for zot users:

```
/mcp setup add you
```

**What it does**

The template registers the keyless You.com MCP profile (`https://api.you.com/mcp?profile=free`, streamable-http). After `/reload-ext`, the model gets `mcp__you__you-search` for current web search — snippets, source URLs, freshness/domain filters. No account, API key, or env var needed for the basic profile.

For the authenticated server with the full You.com tool set, the README now shows the manual config edit: point `url` at `https://api.you.com/mcp` and add an `Authorization: Bearer` header with a `YDC_API_KEY` from [you.com/platform/api-keys](https://you.com/platform/api-keys). I kept the key header out of the template itself so nothing secret lands in `mcp.json` by default — the template stays keyless and the authenticated path is an explicit config change, matching the bridge's note that it has no OAuth flow.

**Changes**

- `setup.go` — one new `you` entry in `setupTemplates()`, same shape as the existing `grep` entry (streamable-http, no headers)
- `setup_test.go` — `TestHandleSetupAddYouGlobal` mirroring the grep test: asserts the transport/URL and that no auth headers get written
- `README.md` — `you` server added to the multi-server example, plus a short "You.com template" section documenting the authenticated upgrade path

Nothing changes for existing users — the template only appears when explicitly added via `/mcp setup add you`.

**Validation**

- `go test ./...`, `go vet ./...`, `gofmt -l .` (clean), and `go build` all pass in `examples/extensions/mcp-bridge` (Go 1.25.5)
- Verified the keyless endpoint live over streamable HTTP: `initialize`, `tools/list`, and a `you-search` call all succeed without auth

Happy to adjust the template name or description, or drop the README section if you'd rather keep that doc minimal.