### PR TITLE
feat: add recursive extension skill discovery

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -60,7 +60,8 @@ Drop it in a directory with this `extension.json`:
 
 `exec` is required for protocol extensions. If an extension only ships
 `theme.json` or `themes/theme.json`, no `exec` is required and zot does
-not spawn a subprocess.
+not spawn a subprocess. A skill-only bundle may instead provide a `skills`
+array and is also never spawned.
 
 `chmod +x hello.py`, install:
 
@@ -130,6 +131,7 @@ manifest tells zot how to launch it:
 | `args` | optional. extra argv passed to `exec`. |
 | `language` | optional. informational only (`go`, `python`, `typescript`, ...). |
 | `description` | optional. shown in `zot ext list`. |
+| `skills` | optional. directories (recursively scanned) or direct `SKILL.md` paths, relative to the manifest. |
 | `enabled` | optional, defaults to `true`. set to `false` to disable without removing. |
 
 ## Lifecycle

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,7 +1,8 @@
 # zot skills
 
 A skill is a reusable instruction set written as a single
-`SKILL.md` file with a YAML frontmatter header. Unless a skill disables
+`SKILL.md` file with a YAML frontmatter header. Skills may be supplied by
+an extension as well as by the normal skill directories. Unless a skill disables
 model invocation, zot discovers it at startup and surfaces it to the model
 in two ways:
 
@@ -34,7 +35,7 @@ When asked to review code, ...
 
 | field | required | purpose |
 |---|---|---|
-| `name` | optional | skill identifier; defaults to the directory name |
+| `name` | optional | skill identifier; defaults to the normalized relative directory path |
 | `description` | required | one-line summary shown in the system prompt |
 | `disable-model-invocation` | optional | when `true`, hide the skill from the model's startup manifest; invoke it explicitly with `/skill:<name>` |
 | `allowed-tools` | optional | list of tool names the skill is meant to use; informational |
@@ -49,7 +50,7 @@ There's no template engine; the model sees what you write.
 
 ## Discovery
 
-zot looks in these directories, in priority order, and registers the
+zot recursively looks in these directories, in priority order, and registers the
 first `SKILL.md` it finds for each unique name:
 
 | location | scope |
@@ -64,7 +65,16 @@ first `SKILL.md` it finds for each unique name:
 The compat paths are deliberate: a `SKILL.md` written for an existing
 skill ecosystem works in zot unchanged. Drop your existing
 `.claude/skills/` or `.agents/skills/` directories into a project and
-zot will pick them up.
+zot will pick them up. When no frontmatter `name` is present, nested path
+components are lowercased and normalized to kebab-case and joined with `-`.
+Only files named exactly `SKILL.md` are read.
+
+Extensions namespace their skills, for example `git-tools:writing-git-commits`.
+Explicit `--ext` bundles take precedence over environment, project, global, and
+compatibility sources. Duplicate names keep the higher-precedence file and
+report a diagnostic. `--no-ext` omits implicit extension bundles;
+`--no-ext --ext PATH` loads only the explicitly named bundle. `--no-skill`
+disables all skills, including extension and built-in skills.
 
 When `XDG_STATE_HOME` is set on any platform, `$ZOT_HOME` defaults to
 `$XDG_STATE_HOME/zot`. Otherwise it defaults to `~/Library/Application Support/zot/`
@@ -113,10 +123,11 @@ are omitted from the model's startup context.
 
 ## Examples
 
-See `examples/skills/` for two starter skills:
+See `examples/skills/` for starter skills:
 
 - `code-review/` — self-review pass on a recent diff
 - `test-fix/` — diagnose + minimally fix a failing test
+- `recursive/` — nested path-derived naming and explicit-name discovery
 
 ## Comparison to other discovery layouts
 

--- a/examples/skills/extension-fixture/README.md
+++ b/examples/skills/extension-fixture/README.md
@@ -1,0 +1,15 @@
+# Skill-only extension fixture
+
+This is a standalone extension bundle containing only filesystem-backed skills.
+It has no executable and therefore does not start a subprocess.
+
+Test it from the repository root with:
+
+```bash
+go run ./cmd/zot --no-ext --ext ./examples/skills/extension-fixture
+```
+
+Run `/skills` in zot. The discovered names are:
+
+- `demo-tools:writing-git-commits` — namespace plus path-derived name
+- `demo-tools:secret-review` — namespace plus explicit frontmatter name

--- a/examples/skills/extension-fixture/extension.json
+++ b/examples/skills/extension-fixture/extension.json
@@ -1,0 +1,7 @@
+{
+  "name": "demo-tools",
+  "version": "1.0.0",
+  "description": "Example skill-only extension bundle",
+  "skills": ["./skills"],
+  "enabled": true
+}

--- a/examples/skills/extension-fixture/skills/security/review-secrets/SKILL.md
+++ b/examples/skills/extension-fixture/skills/security/review-secrets/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: secret-review
+description: Check a change for accidentally exposed credentials and private data.
+allowed-tools: [read, bash]
+---
+
+# Review for secrets
+
+Use this skill before publishing a change or opening a pull request.
+
+- Search the diff for API keys, tokens, private keys, passwords, and session data.
+- Check newly added fixtures and examples as well as source code.
+- Replace real-looking values with clearly synthetic placeholders.
+- Never copy a discovered secret into a report or chat message.

--- a/examples/skills/extension-fixture/skills/writing-git-commits/SKILL.md
+++ b/examples/skills/extension-fixture/skills/writing-git-commits/SKILL.md
@@ -1,0 +1,12 @@
+---
+description: Write clear, focused Git commit messages and keep commits easy to review.
+---
+
+# Writing Git commits
+
+Use this skill when preparing a commit.
+
+1. Inspect the staged diff and identify the user-visible change.
+2. Keep the subject concise, imperative, and specific.
+3. Explain motivation and notable trade-offs in the body when needed.
+4. Verify the final staged diff before committing.

--- a/examples/skills/recursive/README.md
+++ b/examples/skills/recursive/README.md
@@ -1,0 +1,10 @@
+# Recursive skill fixture
+
+This directory demonstrates recursive discovery. The files intentionally use
+both path-derived naming and an explicit frontmatter name:
+
+- `writing-git-commits/SKILL.md` → `writing-git-commits`
+- `security/review-secrets/SKILL.md` → `secret-review`
+
+Run zot from a checkout containing this directory as a skill source, or copy
+its contents into `.zot/skills/`.

--- a/examples/skills/recursive/security/review-secrets/SKILL.md
+++ b/examples/skills/recursive/security/review-secrets/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: secret-review
+description: Check a change for accidentally exposed credentials and private data.
+allowed-tools: [read, bash]
+---
+
+# Review for secrets
+
+Use this skill before publishing a change or opening a pull request.
+
+- Search the diff for API keys, tokens, private keys, passwords, and session data.
+- Check newly added fixtures and examples as well as source code.
+- Replace real-looking values with clearly synthetic placeholders.
+- Report the file and line containing every suspicious value.
+- Never copy a discovered secret into a report or chat message.

--- a/examples/skills/recursive/writing-git-commits/SKILL.md
+++ b/examples/skills/recursive/writing-git-commits/SKILL.md
@@ -1,0 +1,13 @@
+---
+description: Write clear, focused Git commit messages and keep commits easy to review.
+---
+
+# Writing Git commits
+
+Use this skill when preparing a commit.
+
+1. Inspect the staged diff and identify the user-visible change.
+2. Keep the subject concise, imperative, and specific.
+3. Explain motivation and notable trade-offs in the body when needed.
+4. Do not include generated files, credentials, or unrelated changes.
+5. Verify the final staged diff before committing.

--- a/packages/agent/build.go
+++ b/packages/agent/build.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	zotdocs "github.com/patriceckhart/zot"
+	"github.com/patriceckhart/zot/packages/agent/extensions"
 	"github.com/patriceckhart/zot/packages/agent/skills"
 	"github.com/patriceckhart/zot/packages/agent/tools"
 	"github.com/patriceckhart/zot/packages/core"
@@ -595,7 +596,17 @@ func Resolve(args Args, requireCred bool) (Resolved, error) {
 	)
 	if !args.NoSkill {
 		homeDir, _ := os.UserHomeDir()
-		discovered, _ = skills.Discover(ZotHome(), args.CWD, homeDir, args.WithSkills)
+		var sources []skills.Source
+		if args.WithSkills {
+			for _, loc := range skills.SearchSources(ZotHome(), args.CWD, homeDir) {
+				sources = append(sources, loc)
+			}
+		}
+		if !args.NoExt || len(args.Exts) > 0 {
+			extSources, _ := extensions.PlanSkillSources(ZotHome(), args.CWD, args.Exts, !args.NoExt)
+			sources = append(extSources, sources...)
+		}
+		discovered, _ = skills.DiscoverSources(sources, true)
 		if len(discovered) > 0 {
 			skillTool = skills.NewTool(discovered)
 			reg[skillTool.Name()] = skillTool

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -1405,7 +1405,15 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			// model still sees them through the system-prompt
 			// manifest and the skill tool.
 			userHome, _ := os.UserHomeDir()
-			list, _ := skills.Discover(ZotHome(), r.CWD, userHome, args.WithSkills)
+			var sources []skills.Source
+			if args.WithSkills {
+				sources = append(sources, skills.SearchSources(ZotHome(), r.CWD, userHome)...)
+			}
+			if !args.NoExt || len(args.Exts) > 0 {
+				extSources, _ := extensions.PlanSkillSources(ZotHome(), r.CWD, args.Exts, !args.NoExt)
+				sources = append(extSources, sources...)
+			}
+			list, _ := skills.DiscoverSources(sources, true)
 			return skills.VisibleSkills(list)
 		},
 		NoYolo:      args.NoYolo,

--- a/packages/agent/extensions/manager.go
+++ b/packages/agent/extensions/manager.go
@@ -199,19 +199,17 @@ func (m *Manager) Discover(ctx context.Context) []error {
 	var jobs []loadJob
 	seenDirs := map[string]bool{} // dedup by basename so project wins
 	for _, dir := range m.searchDirs() {
-		entries, err := os.ReadDir(dir)
+		extDirs, err := extensionDirs(dir)
 		if err != nil {
 			continue // missing directory is fine
 		}
-		for _, e := range entries {
-			if !e.IsDir() {
-				continue
-			}
-			if seenDirs[e.Name()] {
+		for _, extDir := range extDirs {
+			name := filepath.Base(extDir)
+			if seenDirs[name] {
 				continue // higher-priority location already queued
 			}
-			seenDirs[e.Name()] = true
-			jobs = append(jobs, loadJob{dir: filepath.Join(dir, e.Name())})
+			seenDirs[name] = true
+			jobs = append(jobs, loadJob{dir: extDir})
 		}
 	}
 
@@ -250,6 +248,31 @@ func (m *Manager) searchDirs() []string {
 	return dirs
 }
 
+// extensionDirs returns child directories, including directories reached
+// through symlinks. os.DirEntry.IsDir reports false for a directory symlink.
+func extensionDirs(root string) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		path := filepath.Join(root, entry.Name())
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("stat %s: %w", path, err)
+		}
+		if info.IsDir() {
+			dirs = append(dirs, path)
+		}
+	}
+	return dirs, nil
+}
+
 // PlanSkillSources reads extension manifests without starting processes and
 // returns their filesystem-backed skill roots in precedence order. Explicit
 // extensions win over project and global installations; project wins global.
@@ -274,19 +297,13 @@ func PlanSkillSources(zotHome, cwd string, explicit []string, includeImplicit bo
 	var out []skills.Source
 	var errs []error
 	for _, root := range dirs {
-		entries, err := os.ReadDir(root)
+		candidates, err := extensionDirs(root)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			errs = append(errs, fmt.Errorf("%s: %w", root, err))
 			continue
-		}
-		candidates := make([]string, 0, len(entries))
-		for _, e := range entries {
-			if e.IsDir() {
-				candidates = append(candidates, filepath.Join(root, e.Name()))
-			}
 		}
 		// An explicit --ext points at the extension itself, not its parent.
 		if filepath.Base(root) != "extensions" && filepath.Base(root) != ".zot" {

--- a/packages/agent/extensions/manager.go
+++ b/packages/agent/extensions/manager.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/patriceckhart/zot/packages/agent/extproto"
+	"github.com/patriceckhart/zot/packages/agent/skills"
 	"github.com/patriceckhart/zot/packages/tui"
 )
 
@@ -43,6 +44,7 @@ type Manifest struct {
 	Language    string   `json:"language,omitempty"` // informational ("go", "python", "typescript", ...)
 	Enabled     *bool    `json:"enabled,omitempty"`  // nil = enabled
 	Description string   `json:"description,omitempty"`
+	Skills      []string `json:"skills,omitempty"`
 }
 
 // IsEnabled returns the manifest's effective enabled state. Default
@@ -248,24 +250,127 @@ func (m *Manager) searchDirs() []string {
 	return dirs
 }
 
-// loadOne reads a single extension's manifest and, if enabled,
-// spawns its subprocess + completes the hello handshake.
-func (m *Manager) loadOne(ctx context.Context, dir string) error {
-	manifestPath := filepath.Join(dir, "extension.json")
-	raw, err := os.ReadFile(manifestPath)
+// PlanSkillSources reads extension manifests without starting processes and
+// returns their filesystem-backed skill roots in precedence order. Explicit
+// extensions win over project and global installations; project wins global.
+func PlanSkillSources(zotHome, cwd string, explicit []string, includeImplicit bool) ([]skills.Source, []error) {
+	var dirs []string
+	for _, p := range explicit {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		dirs = append(dirs, abs)
+	}
+	if includeImplicit {
+		if cwd != "" {
+			dirs = append(dirs, filepath.Join(cwd, ".zot", "extensions"))
+		}
+		if zotHome != "" {
+			dirs = append(dirs, filepath.Join(zotHome, "extensions"))
+		}
+	}
+	seen := map[string]bool{}
+	var out []skills.Source
+	var errs []error
+	for _, root := range dirs {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("%s: %w", root, err))
+			continue
+		}
+		candidates := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if e.IsDir() {
+				candidates = append(candidates, filepath.Join(root, e.Name()))
+			}
+		}
+		// An explicit --ext points at the extension itself, not its parent.
+		if filepath.Base(root) != "extensions" && filepath.Base(root) != ".zot" {
+			candidates = []string{root}
+		}
+		for _, dir := range candidates {
+			mf, err := readManifest(dir)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					errs = append(errs, fmt.Errorf("%s: %w", dir, err))
+				}
+				continue
+			}
+			if mf.Name == "" {
+				errs = append(errs, fmt.Errorf("%s: manifest: name is required", dir))
+				continue
+			}
+			if seen[mf.Name] || !mf.IsEnabled() {
+				continue
+			}
+			hasTheme := HasExtensionTheme(dir)
+			if mf.Exec == "" && !hasTheme && len(mf.Skills) == 0 {
+				errs = append(errs, fmt.Errorf("%s: manifest: exec, theme, or skills is required", dir))
+				continue
+			}
+			seen[mf.Name] = true
+			for _, entry := range mf.Skills {
+				path, err := skillEntryPath(dir, entry)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%s: %w", dir, err))
+					continue
+				}
+				label := "extension " + mf.Name
+				out = append(out, skills.Source{Root: path, Label: label, Prefix: skills.KebabCase(mf.Name) + ":"})
+			}
+		}
+	}
+	return out, errs
+}
+
+func readManifest(dir string) (Manifest, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, "extension.json"))
 	if err != nil {
-		return fmt.Errorf("read manifest: %w", err)
+		return Manifest{}, err
 	}
 	var mf Manifest
 	if err := json.Unmarshal(raw, &mf); err != nil {
-		return fmt.Errorf("parse manifest: %w", err)
+		return Manifest{}, fmt.Errorf("parse manifest: %w", err)
+	}
+	return mf, nil
+}
+
+func skillEntryPath(dir, entry string) (string, error) {
+	if strings.TrimSpace(entry) == "" {
+		return "", errors.New("manifest: empty skill path")
+	}
+	path := filepath.Clean(filepath.Join(dir, entry))
+	rel, err := filepath.Rel(dir, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("manifest: skill path %q escapes extension directory", entry)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("manifest: skill path %q: %w", entry, err)
+	}
+	if !info.IsDir() && filepath.Base(path) != "SKILL.md" {
+		return "", fmt.Errorf("manifest: skill path %q is not a directory or SKILL.md", entry)
+	}
+	return path, nil
+}
+
+// loadOne reads a single extension's manifest and, if enabled,
+// spawns its subprocess + completes the hello handshake.
+func (m *Manager) loadOne(ctx context.Context, dir string) error {
+	mf, err := readManifest(dir)
+	if err != nil {
+		return err
 	}
 	if mf.Name == "" {
 		return errors.New("manifest: name is required")
 	}
 	hasTheme := HasExtensionTheme(dir)
-	if mf.Exec == "" && !hasTheme {
-		return errors.New("manifest: exec is required")
+	if mf.Exec == "" && !hasTheme && len(mf.Skills) == 0 {
+		return errors.New("manifest: exec, theme, or skills is required")
 	}
 	if !mf.IsEnabled() {
 		// Quietly skip disabled extensions; zot ext list will show them.

--- a/packages/agent/extensions/manager_test.go
+++ b/packages/agent/extensions/manager_test.go
@@ -219,6 +219,40 @@ func TestSpawnCleansUpProcessAfterInvalidHello(t *testing.T) {
 	}
 }
 
+func TestPlanSkillSourcesFollowsSymlinkedExtension(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory symlinks require elevated privileges on Windows")
+	}
+
+	tmp := t.TempDir()
+	extRoot := filepath.Join(tmp, "extensions")
+	target := filepath.Join(tmp, "target")
+	if err := os.MkdirAll(filepath.Join(target, "skills", "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "extension.json"), []byte(`{"name":"linked","skills":["./skills"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "skills", "review", "SKILL.md"), []byte("---\ndescription: linked\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(extRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(extRoot, "linked")); err != nil {
+		t.Fatal(err)
+	}
+
+	sources, errs := PlanSkillSources(tmp, "", nil, true)
+	if len(errs) != 0 || len(sources) != 1 {
+		t.Fatalf("sources=%#v errs=%v", sources, errs)
+	}
+	got, errs := skills.DiscoverSources(sources, false)
+	if len(errs) != 0 || len(got) != 1 || got[0].Name != "linked:review" {
+		t.Fatalf("skills=%#v errs=%v", got, errs)
+	}
+}
+
 func TestPlanSkillSources(t *testing.T) {
 	tmp := t.TempDir()
 	extDir := filepath.Join(tmp, "bundle")

--- a/packages/agent/extensions/manager_test.go
+++ b/packages/agent/extensions/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/patriceckhart/zot/packages/agent/extproto"
+	"github.com/patriceckhart/zot/packages/agent/skills"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -215,6 +216,45 @@ func TestSpawnCleansUpProcessAfterInvalidHello(t *testing.T) {
 	}
 	if _, err := ext.logFile.WriteString("after cleanup"); err == nil {
 		t.Fatal("failed handshake log file was not closed")
+	}
+}
+
+func TestPlanSkillSources(t *testing.T) {
+	tmp := t.TempDir()
+	extDir := filepath.Join(tmp, "bundle")
+	skillDir := filepath.Join(extDir, "skills", "Writing Git Commits")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\ndescription: commits\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"name":"Git Tools","skills":["./skills"],"enabled":true}`
+	if err := os.WriteFile(filepath.Join(extDir, "extension.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sources, errs := PlanSkillSources("", "", []string{extDir}, false)
+	if len(errs) != 0 || len(sources) != 1 {
+		t.Fatalf("sources=%#v errs=%v", sources, errs)
+	}
+	got, errs := skills.DiscoverSources(sources, false)
+	if len(errs) != 0 || len(got) != 1 || got[0].Name != "git-tools:writing-git-commits" {
+		t.Fatalf("skills=%#v errs=%v", got, errs)
+	}
+}
+
+func TestPlanSkillSourcesRejectsTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	extDir := filepath.Join(tmp, "bundle")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extension.json"), []byte(`{"name":"bad","skills":["../outside"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, errs := PlanSkillSources("", "", []string{extDir}, false)
+	if len(errs) == 0 || !strings.Contains(errs[0].Error(), "escapes") {
+		t.Fatalf("errs=%v", errs)
 	}
 }
 

--- a/packages/agent/skills/skills.go
+++ b/packages/agent/skills/skills.go
@@ -187,7 +187,11 @@ func scanSource(source Source) ([]*Skill, []error) {
 		}
 		return []*Skill{s}, nil
 	}
-	err = filepath.WalkDir(source.Root, func(path string, d os.DirEntry, walkErr error) error {
+	root, err := filepath.EvalSymlinks(source.Root)
+	if err != nil {
+		return out, []error{fmt.Errorf("resolve %s: %w", source.Root, err)}
+	}
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", path, walkErr))
 			return nil
@@ -201,7 +205,7 @@ func scanSource(source Source) ([]*Skill, []error) {
 			return nil
 		}
 		if s.Name == "" {
-			rel, e := filepath.Rel(source.Root, filepath.Dir(path))
+			rel, e := filepath.Rel(root, filepath.Dir(path))
 			if e != nil {
 				errs = append(errs, e)
 				return nil
@@ -226,7 +230,7 @@ func scanSource(source Source) ([]*Skill, []error) {
 		return nil
 	})
 	if err != nil {
-		errs = append(errs, fmt.Errorf("scan %s: %w", source.Root, err))
+		errs = append(errs, fmt.Errorf("scan %s: %w", root, err))
 	}
 	return out, errs
 }

--- a/packages/agent/skills/skills.go
+++ b/packages/agent/skills/skills.go
@@ -32,6 +32,14 @@ import (
 )
 
 // Skill is one discovered SKILL.md file.
+// Source describes one directory of skills. Sources are evaluated in order;
+// the first skill with a canonical name wins.
+type Source struct {
+	Root   string
+	Label  string
+	Prefix string
+}
+
 type Skill struct {
 	// Name is the skill identifier — what the model uses when it
 	// invokes the `skill` tool. Taken from the frontmatter `name`
@@ -102,18 +110,48 @@ func VisibleSkills(in []*Skill) []*Skill {
 // Errors per skill are returned alongside the partial result so a
 // single broken file doesn't suppress the rest.
 func Discover(zotHome, cwd, userHome string, includeUser bool) ([]*Skill, []error) {
+	var sources []Source
+	if includeUser {
+		for _, loc := range searchDirs(zotHome, cwd, userHome) {
+			sources = append(sources, Source{Root: loc.dir, Label: loc.label})
+		}
+	}
+	discovered, errs := DiscoverSources(sources, includeUser)
+	// Preserve the historical Discover contract: duplicate ordinary skills
+	// were silently ignored. New callers using DiscoverSources receive the
+	// richer shadowing diagnostics.
+	filtered := errs[:0]
+	for _, err := range errs {
+		if !strings.Contains(err.Error(), " shadowed: ") {
+			filtered = append(filtered, err)
+		}
+	}
+	return discovered, filtered
+}
+
+// DiscoverSources recursively discovers SKILL.md files from sources in
+// precedence order, then appends built-ins when includeUser is true or false.
+// It returns non-fatal diagnostics for malformed files and shadowed names.
+func DiscoverSources(sources []Source, includeBuiltins bool) ([]*Skill, []error) {
 	var errs []error
 	seen := map[string]*Skill{}
-	if includeUser {
-		errs = append(errs, scanUserSkills(zotHome, cwd, userHome, seen)...)
-	}
-	// Built-ins fill in any name the user didn't already provide
-	// (or every name, when includeUser is false).
-	for _, s := range loadBuiltins() {
-		if _, dup := seen[s.Name]; dup {
-			continue
+	for _, source := range sources {
+		found, scanErrs := scanSource(source)
+		errs = append(errs, scanErrs...)
+		for _, s := range found {
+			if prior, dup := seen[s.Name]; dup {
+				errs = append(errs, fmt.Errorf("skill %q shadowed: selected %s; ignored %s", s.Name, prior.Path, s.Path))
+				continue
+			}
+			seen[s.Name] = s
 		}
-		seen[s.Name] = s
+	}
+	if includeBuiltins {
+		for _, s := range loadBuiltins() {
+			if _, dup := seen[s.Name]; !dup {
+				seen[s.Name] = s
+			}
+		}
 	}
 	out := make([]*Skill, 0, len(seen))
 	for _, s := range seen {
@@ -121,6 +159,96 @@ func Discover(zotHome, cwd, userHome string, includeUser bool) ([]*Skill, []erro
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, errs
+}
+
+func scanSource(source Source) ([]*Skill, []error) {
+	var out []*Skill
+	var errs []error
+	info, err := os.Stat(source.Root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("%s: %w", source.Root, err))
+		}
+		return out, errs
+	}
+	if !info.IsDir() {
+		if filepath.Base(source.Root) != "SKILL.md" {
+			return out, errs
+		}
+		s, e := load(source.Root, source.Label)
+		if e != nil {
+			return out, []error{fmt.Errorf("%s: %w", source.Root, e)}
+		}
+		if s.Name == "" {
+			s.Name = kebabCase(strings.TrimSuffix(filepath.Base(filepath.Dir(source.Root)), ""))
+		}
+		if source.Prefix != "" {
+			s.Name = source.Prefix + s.Name
+		}
+		return []*Skill{s}, nil
+	}
+	err = filepath.WalkDir(source.Root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", path, walkErr))
+			return nil
+		}
+		if d.IsDir() || d.Name() != "SKILL.md" {
+			return nil
+		}
+		s, e := load(path, source.Label)
+		if e != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", path, e))
+			return nil
+		}
+		if s.Name == "" {
+			rel, e := filepath.Rel(source.Root, filepath.Dir(path))
+			if e != nil {
+				errs = append(errs, e)
+				return nil
+			}
+			parts := []string{}
+			if rel != "." {
+				for _, p := range strings.Split(filepath.ToSlash(rel), "/") {
+					if k := kebabCase(p); k != "" {
+						parts = append(parts, k)
+					}
+				}
+			}
+			if len(parts) == 0 {
+				parts = append(parts, kebabCase(filepath.Base(filepath.Dir(path))))
+			}
+			s.Name = strings.Join(parts, "-")
+		}
+		if source.Prefix != "" {
+			s.Name = source.Prefix + s.Name
+		}
+		out = append(out, s)
+		return nil
+	})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("scan %s: %w", source.Root, err))
+	}
+	return out, errs
+}
+
+// KebabCase converts a path component or display name to a stable skill name.
+func KebabCase(s string) string { return kebabCase(s) }
+
+func kebabCase(s string) string {
+	var b strings.Builder
+	sep := false
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			if sep && b.Len() > 0 {
+				b.WriteByte('-')
+			}
+			b.WriteRune(r)
+			sep = false
+		} else {
+			sep = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 // scanUserSkills walks the user-skill search dirs and populates
@@ -227,6 +355,15 @@ func FindByName(skills []*Skill, name string) *Skill {
 type location struct {
 	dir   string
 	label string
+}
+
+// SearchSources returns the ordinary skill roots in precedence order.
+func SearchSources(zotHome, cwd, userHome string) []Source {
+	out := make([]Source, 0)
+	for _, loc := range searchDirs(zotHome, cwd, userHome) {
+		out = append(out, Source{Root: loc.dir, Label: loc.label})
+	}
+	return out
 }
 
 func searchDirs(zotHome, cwd, userHome string) []location {

--- a/packages/agent/skills/skills_test.go
+++ b/packages/agent/skills/skills_test.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -107,6 +108,30 @@ func TestKebabCase(t *testing.T) {
 		if got := KebabCase(in); got != want {
 			t.Errorf("KebabCase(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestDiscoverSourcesFollowsSymlinkedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory symlinks require elevated privileges on Windows")
+	}
+
+	target := t.TempDir()
+	path := filepath.Join(target, "nested", "review")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte("---\ndescription: linked\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(t.TempDir(), "skills")
+	if err := os.Symlink(target, root); err != nil {
+		t.Fatal(err)
+	}
+
+	got, errs := DiscoverSources([]Source{{Root: root, Prefix: "linked:"}}, false)
+	if len(errs) != 0 || len(got) != 1 || got[0].Name != "linked:nested-review" {
+		t.Fatalf("skills=%#v errs=%v", got, errs)
 	}
 }
 

--- a/packages/agent/skills/skills_test.go
+++ b/packages/agent/skills/skills_test.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -91,6 +92,60 @@ func TestDiscoverProjectAndGlobalPriorityAndDedup(t *testing.T) {
 		if FindByName(skills, b.Name) == nil {
 			t.Errorf("built-in skill %q missing from Discover output", b.Name)
 		}
+	}
+}
+
+func TestKebabCase(t *testing.T) {
+	cases := map[string]string{
+		"writing-git-commits": "writing-git-commits",
+		"Writing Git Commits": "writing-git-commits",
+		"git_commits":         "git-commits",
+		"git.commits":         "git-commits",
+		"Git/Commits":         "git-commits",
+	}
+	for in, want := range cases {
+		if got := KebabCase(in); got != want {
+			t.Errorf("KebabCase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDiscoverSourcesRecursiveAndPrefixed(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "Something", "Writing Git Commits")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\ndescription: nested\n---\nbody"
+	if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, errs := DiscoverSources([]Source{{Root: root, Label: "extension Git Tools", Prefix: "git-tools:"}}, false)
+	if len(errs) != 0 {
+		t.Fatalf("errs: %v", errs)
+	}
+	if len(got) != 1 || got[0].Name != "git-tools:something-writing-git-commits" {
+		t.Fatalf("skills = %#v", got)
+	}
+	if got[0].Source != "extension Git Tools" || got[0].Body != "body" {
+		t.Errorf("skill metadata = %#v", got[0])
+	}
+}
+
+func TestDiscoverSourcesDuplicateDiagnostic(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	for _, root := range []string{a, b} {
+		dir := filepath.Join(root, "review")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: review\n---\nbody"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, errs := DiscoverSources([]Source{{Root: a}, {Root: b}}, false)
+	if len(got) != 1 || len(errs) != 1 || !strings.Contains(errs[0].Error(), "shadowed") {
+		t.Fatalf("got=%#v errs=%v", got, errs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the static, filesystem-backed extension skills proposed in [Discussion #161](https://github.com/patriceckhart/zot/discussions/161). Extensions can now ship reusable `SKILL.md` workflows without requiring a runtime subprocess.

## What changed

- Added optional `skills` entries to `extension.json`, accepting directories or direct `SKILL.md` files relative to the manifest.
- Added recursive discovery of files named exactly `SKILL.md`.
- Added stable path-derived kebab-case names for skills without frontmatter `name` values.
- Namespaced extension skills as `<extension-name>:<skill-name>`. Explicit frontmatter names remain supported.
- Added deterministic precedence: explicit `--ext` bundles, project extensions, global extensions, ordinary skill sources, then built-ins. Duplicate names keep the first match and produce a non-fatal shadowing diagnostic.
- Added support for skill-only bundles; they are validated and discovered but never spawned. Existing executable and theme extensions continue to work.
- Wired extension skills into initial skill discovery/system-prompt construction and `/skills` listing.
- Preserved `--no-skill`, `--no-ext`, and `--no-ext --ext PATH` semantics for extension-provided skills.
- Added traversal validation for manifest skill paths.
- Added documentation, recursive-discovery examples, a skill-only extension fixture, and regression tests.

## Validation

- `go test ./...`
- `git diff --check origin/main...HEAD`

Both pass.