### PR TITLE
Expose zot execution to child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,8 @@ A model installed through Ollama is kept in Ollama's internal storage and is not
 
 ## Inline images
 
+Scripts and shell commands launched by zot inherit `ZOT_AGENT=1`. Use this signal when a script needs to distinguish execution inside zot from a standalone invocation.
+
 When a tool returns an image (for example `read` on a PNG), zot renders it inline on terminals that support it: **Ghostty**, **Kitty**, **iTerm2**, **WezTerm**. On other terminals you see a text placeholder with MIME type, pixel dimensions, and byte size. Control with the `ZOT_INLINE_IMAGES` env var:
 
 | Value | Effect |

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ Opening `/model` refreshes the router and lists every loaded model under provide
 
 A model installed through Ollama is kept in Ollama's internal storage and is not automatically available as a llama.cpp GGUF file. Download a GGUF copy through `/llama` or place GGUF files in `~/llama-models`, then restart the router so it discovers files added manually.
 
-## Inline images
+## Child process environment
 
 Scripts and shell commands launched by zot inherit runtime metadata:
 
@@ -830,6 +830,10 @@ Scripts and shell commands launched by zot inherit runtime metadata:
 | `ZOT_REASONING_LEVEL` | Current reasoning level, when configured |
 
 These values contain no credentials. Use `ZOT_AGENT` or `AI_AGENT` to distinguish execution inside zot from a standalone invocation; use the session and model values for diagnostics or attribution.
+
+Interactive shell commands receive model metadata even with `--no-session`; only session ID and file are omitted. Newly launched commands reflect session switches, working-directory changes, and reasoning-level changes. Turning reasoning off removes `ZOT_REASONING_LEVEL`. Already-running subprocesses retain the environment they inherited at launch.
+
+## Inline images
 
 When a tool returns an image (for example `read` on a PNG), zot renders it inline on terminals that support it: **Ghostty**, **Kitty**, **iTerm2**, **WezTerm**. On other terminals you see a text placeholder with MIME type, pixel dimensions, and byte size. Control with the `ZOT_INLINE_IMAGES` env var:
 

--- a/README.md
+++ b/README.md
@@ -816,7 +816,20 @@ A model installed through Ollama is kept in Ollama's internal storage and is not
 
 ## Inline images
 
-Scripts and shell commands launched by zot inherit `ZOT_AGENT=1`. Use this signal when a script needs to distinguish execution inside zot from a standalone invocation.
+Scripts and shell commands launched by zot inherit runtime metadata:
+
+| Variable | Meaning |
+| --- | --- |
+| `AI_AGENT` | Generic agent marker, set to `zot` |
+| `ZOT_AGENT` | Zot-specific process marker, set to `1` |
+| `ZOT_CHILD_SESSION` | Set to `1` for commands launched by a zot tool |
+| `ZOT_SESSION_ID` | Current session ID, when session persistence is enabled |
+| `ZOT_SESSION_FILE` | Absolute path to the current session file, when persisted |
+| `ZOT_PROVIDER` | Current model provider |
+| `ZOT_MODEL` | Current model ID |
+| `ZOT_REASONING_LEVEL` | Current reasoning level, when configured |
+
+These values contain no credentials. Use `ZOT_AGENT` or `AI_AGENT` to distinguish execution inside zot from a standalone invocation; use the session and model values for diagnostics or attribution.
 
 When a tool returns an image (for example `read` on a PNG), zot renders it inline on terminals that support it: **Ghostty**, **Kitty**, **iTerm2**, **WezTerm**. On other terminals you see a text placeholder with MIME type, pixel dimensions, and byte size. Control with the `ZOT_INLINE_IMAGES` env var:
 

--- a/packages/agent/args_test.go
+++ b/packages/agent/args_test.go
@@ -98,6 +98,16 @@ func TestRunHelpHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
+func TestRunSetsAgentEnvironment(t *testing.T) {
+	t.Setenv("ZOT_AGENT", "")
+	if err := Run([]string{"--help"}, "test"); err != nil {
+		t.Fatalf("Run returned %v", err)
+	}
+	if got := os.Getenv("ZOT_AGENT"); got != "1" {
+		t.Fatalf("ZOT_AGENT = %q, want %q", got, "1")
+	}
+}
+
 func TestHelpOutputStreams(t *testing.T) {
 	run := func(args string) (stdout, stderr string, err error) {
 		t.Helper()

--- a/packages/agent/args_test.go
+++ b/packages/agent/args_test.go
@@ -100,6 +100,8 @@ func TestRunHelpHelperProcess(t *testing.T) {
 
 func TestRunSetsAgentEnvironment(t *testing.T) {
 	t.Setenv("ZOT_AGENT", "")
+	t.Setenv("AI_AGENT", "")
+	isolateSessionEnvironment(t)
 	if err := Run([]string{"--help"}, "test"); err != nil {
 		t.Fatalf("Run returned %v", err)
 	}

--- a/packages/agent/args_test.go
+++ b/packages/agent/args_test.go
@@ -106,6 +106,9 @@ func TestRunSetsAgentEnvironment(t *testing.T) {
 	if got := os.Getenv("ZOT_AGENT"); got != "1" {
 		t.Fatalf("ZOT_AGENT = %q, want %q", got, "1")
 	}
+	if got := os.Getenv("AI_AGENT"); got != "zot" {
+		t.Fatalf("AI_AGENT = %q, want %q", got, "zot")
+	}
 }
 
 func TestHelpOutputStreams(t *testing.T) {

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -952,7 +952,7 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 	// (run on the TUI goroutine). Without this, a /sessions swap that
 	// races with a finishing turn could double-write or lose messages.
 	var persistMu sync.Mutex
-	if !args.NoSess && ag != nil {
+	if ag != nil {
 		sess, _ = openOrCreateSession(args, r, ag, version)
 		if ag != nil {
 			sessBaselineMsgs = len(ag.Messages())
@@ -1209,6 +1209,10 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			bindAgentSession(newAg, newSess)
 		}
 
+		r.Provider = newProvider
+		r.Model = newModel
+		r.Reasoning = newAg.Reasoning
+		setZotSessionEnvironment(r, sess)
 		startExtensionSession(extMgr, newAg, absPath, "cwd_change")
 
 		// Push the new state into the running Interactive.
@@ -1468,6 +1472,10 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		},
 		NoYolo:      args.NoYolo,
 		ConfirmGate: confirmGate,
+		OnReasoningChanged: func(level string) {
+			r.Reasoning = level
+			setZotSessionEnvironment(r, sess)
+		},
 		PersistModel: func(providerName, model string) {
 			// Update config.json so next launch uses the same pick.
 			cfg, _ := LoadConfig()

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -208,8 +208,13 @@ func fanoutAgentEvent(mgr *extensions.Manager, ev core.AgentEvent) {
 func Run(rawArgs []string, version string) error {
 	// Mark the process and all child processes as running under zot. This
 	// lets shell tools, extensions, and scripts distinguish zot execution
-	// from an ordinary invocation.
+	// from an ordinary invocation. Clear per-session values because embedded
+	// callers may invoke Run more than once in one process.
+	_ = os.Setenv("AI_AGENT", "zot")
 	_ = os.Setenv("ZOT_AGENT", "1")
+	for _, name := range []string{"ZOT_SESSION_ID", "ZOT_SESSION_FILE", "ZOT_PROVIDER", "ZOT_MODEL", "ZOT_REASONING_LEVEL"} {
+		_ = os.Unsetenv(name)
+	}
 
 	// Apply network configuration before any subcommand can make an HTTP
 	// request. Standard proxy environment variables retain precedence.
@@ -1065,6 +1070,7 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 		sess = newSess
 		currentAg.SetMessages(msgs)
 		bindAgentSession(currentAg, sess)
+		setZotSessionEnvironment(r, sess)
 		startExtensionSession(extMgr, currentAg, r.CWD, "session_switch")
 		if cum, last, uerr := core.SessionUsageDetail(path); uerr == nil {
 			currentAg.SeedCost(cum)
@@ -1472,6 +1478,9 @@ func runInteractive(ctx context.Context, args Args, version string) error {
 			if sess != nil {
 				_ = sess.UpdateModel(providerName, model)
 			}
+			r.Provider = providerName
+			r.Model = model
+			setZotSessionEnvironment(r, sess)
 		},
 	})
 
@@ -1548,6 +1557,7 @@ func agentSessionsRoot(root string, args Args) string {
 // exists, its id is bound onto ag so providers can sticky-route.
 func openOrCreateSession(args Args, r Resolved, ag *core.Agent, version string) (*core.Session, error) {
 	if args.NoSess {
+		setZotSessionEnvironment(r, nil)
 		return nil, nil
 	}
 	// Sweep meta-only files left over from older zot versions (and from
@@ -1605,7 +1615,29 @@ func openOrCreateSession(args Args, r Resolved, ag *core.Agent, version string) 
 		}
 	}
 	bindAgentSession(ag, s)
+	setZotSessionEnvironment(r, s)
 	return s, nil
+}
+
+// setZotSessionEnvironment publishes the non-secret runtime metadata that
+// zot's child processes can use for attribution and diagnostics.
+func setZotSessionEnvironment(r Resolved, sess *core.Session) {
+	values := map[string]string{
+		"ZOT_PROVIDER":        r.Provider,
+		"ZOT_MODEL":           r.Model,
+		"ZOT_REASONING_LEVEL": r.Reasoning,
+	}
+	if sess != nil {
+		values["ZOT_SESSION_ID"] = sess.ID
+		values["ZOT_SESSION_FILE"] = sess.Path
+	}
+	for _, name := range []string{"ZOT_SESSION_ID", "ZOT_SESSION_FILE", "ZOT_PROVIDER", "ZOT_MODEL", "ZOT_REASONING_LEVEL"} {
+		if value := values[name]; value != "" {
+			_ = os.Setenv(name, value)
+		} else {
+			_ = os.Unsetenv(name)
+		}
+	}
 }
 
 func pickSession(root, cwd string) (string, error) {

--- a/packages/agent/cli.go
+++ b/packages/agent/cli.go
@@ -206,6 +206,11 @@ func fanoutAgentEvent(mgr *extensions.Manager, ev core.AgentEvent) {
 
 // Run is the top-level entrypoint for the zot binary.
 func Run(rawArgs []string, version string) error {
+	// Mark the process and all child processes as running under zot. This
+	// lets shell tools, extensions, and scripts distinguish zot execution
+	// from an ordinary invocation.
+	_ = os.Setenv("ZOT_AGENT", "1")
+
 	// Apply network configuration before any subcommand can make an HTTP
 	// request. Standard proxy environment variables retain precedence.
 	applyConfiguredHTTPProxy()

--- a/packages/agent/modes/interactive.go
+++ b/packages/agent/modes/interactive.go
@@ -269,6 +269,9 @@ type InteractiveConfig struct {
 	// write a new meta row so resume picks up the same model.
 	PersistModel func(providerName, model string)
 
+	// OnReasoningChanged reports the normalized level after updating the live agent.
+	OnReasoningChanged func(level string)
+
 	OnAssistant  func(m provider.Message)
 	OnToolResult func(id string, r core.ToolResult)
 
@@ -4196,6 +4199,9 @@ func (i *Interactive) applyReasoningSetting(level string) {
 	i.statusOK = "reasoning level " + label
 	i.statusErr = ""
 	i.mu.Unlock()
+	if i.cfg.OnReasoningChanged != nil {
+		i.cfg.OnReasoningChanged(level)
+	}
 }
 
 // buildStudyPrompt returns the canned prompt the /study command

--- a/packages/agent/modes/interactive_model_test.go
+++ b/packages/agent/modes/interactive_model_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/patriceckhart/zot/packages/core"
 	"github.com/patriceckhart/zot/packages/tui"
 )
 
@@ -78,6 +79,22 @@ func TestReasoningCommandOpensDirectSelector(t *testing.T) {
 	act = i.settingsDialog.HandleKey(tui.Key{Kind: tui.KeyEsc})
 	if !act.Close || i.settingsDialog.Active() {
 		t.Fatal("escape did not close the direct reasoning selector")
+	}
+}
+
+func TestReasoningSettingNotifiesRuntime(t *testing.T) {
+	i := &Interactive{agent: &core.Agent{Reasoning: "high"}}
+	var levels []string
+	i.cfg.OnReasoningChanged = func(level string) {
+		if i.agent.Reasoning != level {
+			t.Fatalf("callback ran before agent update: got %q, want %q", i.agent.Reasoning, level)
+		}
+		levels = append(levels, level)
+	}
+	i.applyReasoningSetting("medium")
+	i.applyReasoningSetting("off")
+	if !slices.Equal(levels, []string{"medium", ""}) {
+		t.Fatalf("reasoning notifications = %q", levels)
 	}
 }
 

--- a/packages/agent/session_environment_test.go
+++ b/packages/agent/session_environment_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/patriceckhart/zot/packages/core"
+)
+
+func isolateSessionEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"ZOT_SESSION_ID", "ZOT_SESSION_FILE", "ZOT_PROVIDER", "ZOT_MODEL", "ZOT_REASONING_LEVEL"} {
+		t.Setenv(name, "inherited")
+	}
+}
+
+func assertSessionEnvironment(t *testing.T, r Resolved, sess *core.Session) {
+	t.Helper()
+	want := map[string]string{
+		"ZOT_SESSION_ID": "", "ZOT_SESSION_FILE": "",
+		"ZOT_PROVIDER": r.Provider, "ZOT_MODEL": r.Model, "ZOT_REASONING_LEVEL": r.Reasoning,
+	}
+	if sess != nil {
+		want["ZOT_SESSION_ID"] = sess.ID
+		want["ZOT_SESSION_FILE"] = sess.Path
+	}
+	for name, value := range want {
+		got, present := os.LookupEnv(name)
+		if got != value || present != (value != "") {
+			t.Errorf("%s = %q (present=%v), want %q (present=%v)", name, got, present, value, value != "")
+		}
+	}
+}
+
+func TestOpenSessionWithoutPersistencePublishesModelEnvironment(t *testing.T) {
+	isolateSessionEnvironment(t)
+	r := Resolved{Provider: "test-provider", Model: "test-model", Reasoning: "high"}
+	sess, err := openOrCreateSession(Args{NoSess: true}, r, nil, "test")
+	if err != nil || sess != nil {
+		t.Fatalf("openOrCreateSession = %v, %v; want nil, nil", sess, err)
+	}
+	assertSessionEnvironment(t, r, nil)
+}
+
+func TestSessionEnvironmentReplacesSessionAndClearsReasoning(t *testing.T) {
+	isolateSessionEnvironment(t)
+	r := Resolved{Provider: "old-provider", Model: "old-model", Reasoning: "high"}
+	oldSession := &core.Session{ID: "old", Path: filepath.Join(t.TempDir(), "old.jsonl")}
+	setZotSessionEnvironment(r, oldSession)
+	assertSessionEnvironment(t, r, oldSession)
+
+	// A directory change replaces the session and may rebuild a different model.
+	r.Provider, r.Model, r.Reasoning = "new-provider", "new-model", "medium"
+	newSession := &core.Session{ID: "new", Path: filepath.Join(t.TempDir(), "new.jsonl")}
+	setZotSessionEnvironment(r, newSession)
+	assertSessionEnvironment(t, r, newSession)
+
+	r.Reasoning = ""
+	setZotSessionEnvironment(r, newSession)
+	assertSessionEnvironment(t, r, newSession)
+
+	setZotSessionEnvironment(r, nil)
+	assertSessionEnvironment(t, r, nil)
+}

--- a/packages/agent/tools/bash.go
+++ b/packages/agent/tools/bash.go
@@ -81,7 +81,9 @@ func executeShell(ctx context.Context, raw json.RawMessage, progress func(string
 		return core.ToolResult{}, err
 	}
 	cmd.Dir = cwd
-	cmd.Env = os.Environ()
+	// Mark direct tool subprocesses separately from the zot process itself.
+	// Descendants inherit this marker as usual.
+	cmd.Env = append(os.Environ(), "ZOT_CHILD_SESSION=1")
 	// Bound output draining if descendants retain handles after cancellation.
 	cmd.WaitDelay = 2 * time.Second
 	setProcessGroup(cmd)

--- a/packages/agent/tools/tools_test.go
+++ b/packages/agent/tools/tools_test.go
@@ -355,6 +355,21 @@ func TestBashSuccess(t *testing.T) {
 	}
 }
 
+func TestBashExposesChildSessionMarker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix shell only")
+	}
+	tool := &BashTool{CWD: t.TempDir()}
+	res, err := tool.Execute(context.Background(), mustJSON(t, map[string]any{"command": "printf '%s' \"$ZOT_CHILD_SESSION\""}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := res.Content[0].(provider.TextBlock).Text
+	if !strings.Contains(got, "1") {
+		t.Fatalf("ZOT_CHILD_SESSION = %q, want 1", got)
+	}
+}
+
 func TestBashSyntax(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash syntax is not used on Windows")


### PR DESCRIPTION
## Summary

- expose `AI_AGENT=zot` as a generic agent marker
- retain `ZOT_AGENT=1` as the zot-specific marker
- expose `ZOT_CHILD_SESSION=1` to Bash tool subprocesses
- expose non-secret session metadata to child processes:
  - `ZOT_SESSION_ID`
  - `ZOT_SESSION_FILE`
  - `ZOT_PROVIDER`
  - `ZOT_MODEL`
  - `ZOT_REASONING_LEVEL`
- refresh session metadata when sessions are opened, resumed, switched, or models change
- document the environment variables and add regression coverage

These variables are intended for subprocess attribution, diagnostics, and tooling integration. They do not contain credentials.

## Research

The environment contract follows conventions used by other coding agents:

- Pi exposes a generic `AI_AGENT` marker, an agent-specific marker, and session/model metadata.
- Claude Code exposes a child-session marker for subprocesses launched by agent tools.
- Codex exposes execution-context variables such as sandbox and network state.

## Proposed follow-ups

The research also identified these useful environment variables that are proposed for a later change but are not implemented in this PR:

- `ZOT_SANDBOX` — current sandbox mode, when one is active
- `ZOT_SANDBOX_NETWORK_DISABLED=1` — indicates that child network access is unavailable
- `ZOT_HOME` — resolved zot state/configuration directory

## Validation

- `go test ./...`
- `git diff --check`
