### PR TITLE
Improve extension startup errors for missing runtimes

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -880,7 +880,11 @@ error in red, including its message, and dismisses itself after five
 seconds. Extension failures from startup and `/reload-ext` remain in the
 scrolling chat until a successful reload or `/clear`, without being sent to
 the model or saved in the session transcript. Subprocess startup and
-handshake errors include the exact stderr log path for the failed extension.
+handshake errors identify the extension and its directory, configured executable,
+and declared language (if present), along with the original error and stderr log
+path when the log was opened. Manifest errors also identify the extension
+directory. Multiline diagnostics preserve their line breaks in both the temporary
+status and scrolling chat.
 If a subprocess exits before sending `hello`, the error also reports its exit
 status or terminating signal.
 

--- a/packages/agent/extensions/manager.go
+++ b/packages/agent/extensions/manager.go
@@ -396,14 +396,14 @@ func skillEntryPath(dir, entry string) (string, error) {
 func (m *Manager) loadOne(ctx context.Context, dir string) error {
 	mf, err := readManifest(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %w", dir, err)
 	}
 	if mf.Name == "" {
-		return errors.New("manifest: name is required")
+		return fmt.Errorf("%s: manifest: name is required", dir)
 	}
 	hasTheme := HasExtensionTheme(dir)
 	if mf.Exec == "" && !hasTheme && len(mf.Skills) == 0 {
-		return errors.New("manifest: exec, theme, or skills is required")
+		return fmt.Errorf("%s: manifest: exec, theme, or skills is required", dir)
 	}
 	if !mf.IsEnabled() {
 		// Quietly skip disabled extensions; zot ext list will show them.
@@ -430,7 +430,15 @@ func (m *Manager) loadOne(ctx context.Context, dir string) error {
 	}
 	if mf.Exec != "" {
 		if err := m.spawn(ctx, ext); err != nil {
-			return err
+			language := ""
+			if mf.Language != "" {
+				language = fmt.Sprintf(" (declared language: %q)", mf.Language)
+			}
+			logDetail := ""
+			if ext.LogPath != "" {
+				logDetail = "\n  stderr log: " + ext.LogPath
+			}
+			return fmt.Errorf("Extension %s failed to start.\n\n  exec: %q%s\n  error: %w\n  extension directory: %s%s", mf.Name, mf.Exec, language, err, dir, logDetail)
 		}
 	} else {
 		ext.readyOnce.Do(func() { close(ext.readyCh) })
@@ -727,11 +735,7 @@ func (m *Manager) spawn(ctx context.Context, ext *Extension) error {
 		return fmt.Errorf("stdout pipe (stderr log: %s): %w", logPath, err)
 	}
 	if err := cmd.Start(); err != nil {
-		language := ""
-		if ext.Manifest.Language != "" {
-			language = fmt.Sprintf(" (declared language: %q)", ext.Manifest.Language)
-		}
-		return fmt.Errorf("Extension %s failed to start.\n\n  exec: %q%s\n  error: %w\n  extension directory: %s\n  stderr log: %s", ext.Manifest.Name, ext.Manifest.Exec, language, err, ext.Dir, logPath)
+		return err
 	}
 	started = true
 	ext.cmd = cmd

--- a/packages/agent/extensions/manager.go
+++ b/packages/agent/extensions/manager.go
@@ -229,7 +229,7 @@ func (m *Manager) Discover(ctx context.Context) []error {
 		go func(extDir string) {
 			defer wg.Done()
 			if err := m.loadOne(ctx, extDir); err != nil {
-				errCh <- fmt.Errorf("%s: %w", extDir, err)
+				errCh <- err
 			}
 		}(j.dir)
 	}
@@ -506,7 +506,7 @@ func (m *Manager) LoadExplicit(ctx context.Context, paths []string) []error {
 		go func(extDir string) {
 			defer wg.Done()
 			if err := m.loadOne(ctx, extDir); err != nil {
-				errCh <- fmt.Errorf("%s: %w", extDir, err)
+				errCh <- err
 			}
 		}(abs)
 	}
@@ -727,7 +727,11 @@ func (m *Manager) spawn(ctx context.Context, ext *Extension) error {
 		return fmt.Errorf("stdout pipe (stderr log: %s): %w", logPath, err)
 	}
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("spawn (stderr log: %s): %w", logPath, err)
+		language := ""
+		if ext.Manifest.Language != "" {
+			language = fmt.Sprintf(" (declared language: %q)", ext.Manifest.Language)
+		}
+		return fmt.Errorf("Extension %s failed to start.\n\n  exec: %q%s\n  error: %w\n  extension directory: %s\n  stderr log: %s", ext.Manifest.Name, ext.Manifest.Exec, language, err, ext.Dir, logPath)
 	}
 	started = true
 	ext.cmd = cmd

--- a/packages/agent/extensions/manager_diagnostics_test.go
+++ b/packages/agent/extensions/manager_diagnostics_test.go
@@ -1,0 +1,71 @@
+package extensions
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadErrorsIdentifyExtensionDirectory(t *testing.T) {
+	for _, explicit := range []bool{false, true} {
+		mode := "discover"
+		if explicit {
+			mode = "explicit"
+		}
+		for _, tc := range []struct {
+			name     string
+			manifest string
+			want     string
+		}{
+			{"invalid-json", `{`, "parse manifest"},
+			{"missing-name", `{"exec":"missing"}`, "name is required"},
+			{"missing-exec", `{"name":"broken"}`, "exec, theme, or skills is required"},
+			{"open-log", `{"name":"broken","exec":"missing"}`, "open log"},
+			{"missing-runtime", `{"name":"broken","exec":"zot-test-missing-runtime"}`, "failed to start"},
+		} {
+			t.Run(mode+"/"+tc.name, func(t *testing.T) {
+				home := t.TempDir()
+				dir := filepath.Join(home, "extensions", tc.name)
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "extension.json"), []byte(tc.manifest), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if tc.name == "open-log" {
+					if err := os.WriteFile(filepath.Join(home, "logs"), nil, 0o644); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if tc.name == "missing-runtime" {
+					t.Setenv("PATH", t.TempDir())
+				}
+				mgr := New(home, "", "test", "", "", nil)
+				var errs []error
+				if explicit {
+					errs = mgr.LoadExplicit(context.Background(), []string{dir})
+				} else {
+					errs = mgr.Discover(context.Background())
+				}
+				if len(errs) != 1 {
+					t.Fatalf("errors = %v, want one", errs)
+				}
+				if got := errs[0].Error(); !strings.Contains(got, dir) || !strings.Contains(got, tc.want) {
+					t.Fatalf("error = %q, want directory %q and %q", got, dir, tc.want)
+				}
+				if tc.name == "missing-runtime" {
+					if !errors.Is(errs[0], exec.ErrNotFound) {
+						t.Fatalf("error does not wrap exec.ErrNotFound: %v", errs[0])
+					}
+					if strings.Count(errs[0].Error(), dir) != 1 {
+						t.Fatalf("directory should appear once: %v", errs[0])
+					}
+				}
+			})
+		}
+	}
+}

--- a/packages/agent/extensions/manager_test.go
+++ b/packages/agent/extensions/manager_test.go
@@ -160,6 +160,37 @@ func TestDiscoverReportsExitStatusAndLogWhenExtensionExitsBeforeHello(t *testing
 	}
 }
 
+func TestDiscoverReportsMissingRuntimeWhenExtensionCannotStart(t *testing.T) {
+	tmp := t.TempDir()
+	extDir := filepath.Join(tmp, "extensions", "missing-runtime")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extension.json"), []byte(`{"name":"missing-runtime","exec":"python3","language":"python"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Isolate PATH so this tests a missing language runtime rather than
+	// relying on a made-up executable name that could theoretically exist.
+	t.Setenv("PATH", filepath.Join(tmp, "empty-bin"))
+	mgr := New(tmp, "", "0.0.0-test", "", "", nil)
+	errs := mgr.Discover(context.Background())
+	if len(errs) != 1 {
+		t.Fatalf("discover errors = %v, want one", errs)
+	}
+	got := errs[0].Error()
+	for _, want := range []string{
+		`Extension missing-runtime failed to start.`,
+		`exec: "python3"`,
+		`declared language: "python"`,
+		"executable file not found",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
 func TestDiscoverReportsSignalWhenExtensionExitsBeforeHello(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mock extension uses Unix signals; skip on windows")

--- a/packages/agent/modes/reload_ext.go
+++ b/packages/agent/modes/reload_ext.go
@@ -55,16 +55,21 @@ func renderReloadErrors(theme tui.Theme, errors []string, width int) []string {
 	}
 	var out []string
 	for _, msg := range errors {
-		wrapped := tui.WrapANSILine(msg, wrapWidth)
-		if len(wrapped) == 0 {
-			wrapped = []string{""}
-		}
-		for idx, line := range wrapped {
-			prefix := marker
-			if idx > 0 {
-				prefix = indent
+		// Split explicit newlines before wrapping. Passing a multiline string
+		// to WrapANSILine would leave the terminal to interpret the embedded
+		// newline, which can misalign the continuation text.
+		for lineIndex, paragraph := range strings.Split(msg, "\n") {
+			wrapped := tui.WrapANSILine(paragraph, wrapWidth)
+			if len(wrapped) == 0 {
+				wrapped = []string{""}
 			}
-			out = append(out, theme.FG256(theme.Error, prefix+line))
+			for wrapIndex, line := range wrapped {
+				prefix := indent
+				if lineIndex == 0 && wrapIndex == 0 {
+					prefix = marker
+				}
+				out = append(out, theme.FG256(theme.Error, prefix+line))
+			}
 		}
 	}
 	return out

--- a/packages/agent/modes/reload_ext_test.go
+++ b/packages/agent/modes/reload_ext_test.go
@@ -35,6 +35,21 @@ func TestFormatReloadStatusIncludesErrorDetails(t *testing.T) {
 	}
 }
 
+func TestRenderReloadErrorsPreservesMultilineAlignment(t *testing.T) {
+	lines := renderReloadErrors(tui.Theme{Error: 1}, []string{"failed to start\nextension directory: /tmp/ext\nstderr log: /tmp/ext.log"}, 80)
+	if len(lines) != 3 {
+		t.Fatalf("rendered %d lines, want 3: %q", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "✖ failed to start") {
+		t.Fatalf("first line = %q, want error marker", lines[0])
+	}
+	for _, line := range lines[1:] {
+		if !strings.Contains(line, "  ") {
+			t.Fatalf("continuation line = %q, want indentation", line)
+		}
+	}
+}
+
 func TestFormatReloadStatusSuccess(t *testing.T) {
 	msg, failed := formatReloadStatus(extensions.ReloadStats{Stopped: 2, Loaded: 3, Ready: 3})
 	if failed {

--- a/packages/tui/view.go
+++ b/packages/tui/view.go
@@ -319,17 +319,17 @@ func (v *View) renderErr(width int) []string {
 	if wrapWidth < 8 {
 		wrapWidth = 8
 	}
-	wrapped := wrapLine(v.Err, wrapWidth, "")
-	if len(wrapped) == 0 {
-		wrapped = []string{""}
-	}
-	out := make([]string, 0, len(wrapped))
-	for idx, line := range wrapped {
-		prefix := marker
-		if idx > 0 {
-			prefix = indent
+	var out []string
+	// Each returned row must represent one terminal line, including when
+	// the error contains explicit newlines or blank separator lines.
+	for _, paragraph := range strings.Split(v.Err, "\n") {
+		for _, line := range wrapLine(paragraph, wrapWidth, "") {
+			prefix := indent
+			if len(out) == 0 {
+				prefix = marker
+			}
+			out = append(out, v.Theme.FG256(v.Theme.Error, prefix+line))
 		}
-		out = append(out, v.Theme.FG256(v.Theme.Error, prefix+line))
 	}
 	return out
 }

--- a/packages/tui/view_error_test.go
+++ b/packages/tui/view_error_test.go
@@ -1,0 +1,28 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderErrSplitsExplicitNewlines(t *testing.T) {
+	v := &View{Theme: Theme{Error: 1}, Err: "failed to start\n\n  exec: python3\nstderr log: /tmp/ext.log"}
+	want := []string{"✖ failed to start", "  ", "    exec: python3", "  stderr log: /tmp/ext.log"}
+	rows := v.renderErr(80)
+	if len(rows) != len(want) {
+		t.Fatalf("rows = %q, want %d rows", rows, len(want))
+	}
+	for n, row := range rows {
+		if expected := v.Theme.FG256(v.Theme.Error, want[n]); row != expected {
+			t.Errorf("row %d = %q, want %q", n, row, expected)
+		}
+	}
+	for _, row := range v.renderErr(20) {
+		if strings.ContainsAny(row, "\r\n") {
+			t.Errorf("row contains a newline: %q", row)
+		}
+		if width := visibleWidth(row); width > 20 {
+			t.Errorf("row width = %d, want <= 20: %q", width, row)
+		}
+	}
+}


### PR DESCRIPTION
Closes no issue; related discussion: https://github.com/patriceckhart/zot/discussions/162

## Summary

When an extension executable or language runtime is unavailable, startup currently reports a dense, path-prefixed error that is difficult to diagnose.

This change:

- reports the extension name, configured executable, declared language, original OS error, extension directory, and stderr log
- formats the diagnostic as a readable multiline block with spacing and indentation
- preserves the existing non-fatal behavior when an extension cannot start
- adds regression coverage for missing executables and multiline error rendering

Example:

```text
Extension missing-runtime failed to start.

  exec: "python3" (declared language: "python")
  error: executable file not found in $PATH
  extension directory: /path/to/extensions/missing-runtime
  stderr log: /path/to/zot/logs/ext-missing-runtime.log
```

Validation: `go test ./...`

## repro: 

Testing language:

```
> env PATH=/tmp/zot-empty-path \
    /home/zenobius/.local/share/mise/installs/go/1.25.0/bin/go run ./cmd/zot \
    --no-ext --ext /tmp/zot-missing-runtime-extension \
    -p hello
    
extension load: Extension missing-python-runtime failed to start.

  exec: "python3" (declared language: "python")
  error: exec: "python3": executable file not found in $PATH
  extension directory: /tmp/zot-missing-runtime-extension
  stderr log: /home/zenobius/.local/state/zot/logs/ext-missing-python-runtime.log
Hello! How can I help?
```
<img width="1892" height="548" alt="image" src="https://github.com/user-attachments/assets/920edb04-64a7-4491-9877-44d2511b1c6c" />


Testing exec: 

```
> cd /var/home/zenobius/Projects/zot.worktrees/ext-spawn-diagnostics

  /home/zenobius/.local/share/mise/installs/go/1.25.0/bin/go run ./cmd/zot \
    --no-ext \
    --ext /tmp/zot-missing-exec-extension \
    --api-key dummy \
    -p hello
extension load: Extension missing-exec failed to start.

  exec: "zot-test-executable-not-installed"
  error: exec: "zot-test-executable-not-installed": executable file not found in $PATH
  extension directory: /tmp/zot-missing-exec-extension
  stderr log: /home/zenobius/.local/state/zot/logs/ext-missing-exec.log
Hello! What would you like help with?
```

<img width="1892" height="548" alt="image" src="https://github.com/user-attachments/assets/5a1e47ac-8379-4ff3-97ea-c17118808178" />

